### PR TITLE
change debugPort to a string.

### DIFF
--- a/src/main/java/io/reactiverse/vertx/maven/plugin/mojos/DebugMojo.java
+++ b/src/main/java/io/reactiverse/vertx/maven/plugin/mojos/DebugMojo.java
@@ -41,7 +41,7 @@ public class DebugMojo extends RunMojo {
     boolean debugSuspend;
 
     @Parameter(property = "debug.port", defaultValue = "5005")
-    int debugPort;
+    String debugPort;
 
 
     @Override


### PR DESCRIPTION
Here is a pull request to allow strings. This will allow the port to be set to *:5005 which will allow java 9 and 10 access it in a docker image.