### PR TITLE
resolve the space error in the classpath.

### DIFF
--- a/src/main/java/io/reactiverse/vertx/maven/plugin/mojos/AbstractRunMojo.java
+++ b/src/main/java/io/reactiverse/vertx/maven/plugin/mojos/AbstractRunMojo.java
@@ -204,11 +204,13 @@ public class AbstractRunMojo extends AbstractVertxMojo {
     void addClasspath(List<String> args) throws MojoExecutionException {
         try {
             StringBuilder classpath = new StringBuilder();
+            classpath.append("\"");
             for (URL ele : getClassPathUrls()) {
                 classpath = classpath
-                    .append(classpath.length() > 0 ? File.pathSeparator : "")
+                    .append(classpath.length() > 1 ? File.pathSeparator : "")
                     .append(new File(ele.toURI()));
             }
+            classpath.append("\"");
             getLog().debug("Classpath for forked process: " + classpath);
             args.add("-cp");
             args.add(classpath.toString());

--- a/src/main/java/io/reactiverse/vertx/maven/plugin/mojos/StartMojo.java
+++ b/src/main/java/io/reactiverse/vertx/maven/plugin/mojos/StartMojo.java
@@ -98,7 +98,7 @@ public class StartMojo extends AbstractRunMojo {
                 argsList.add(fatjar.getAbsolutePath());
             } else if (fatjar.isFile()  && ! isVertxLauncher(launcher)) {
                 argsList.add("-cp");
-                argsList.add(fatjar.getAbsolutePath());
+                argsList.add("\"" + fatjar.getAbsolutePath() + "\"");
                 argsList.add(IO_VERTX_CORE_LAUNCHER);
             } else {
                 throw new MojoFailureException("Unable to find vertx application jar --> "

--- a/src/main/java/io/reactiverse/vertx/maven/plugin/utils/JavaProcessExecutor.java
+++ b/src/main/java/io/reactiverse/vertx/maven/plugin/utils/JavaProcessExecutor.java
@@ -179,10 +179,10 @@ public class JavaProcessExecutor {
         try {
 
             StringBuilder classpath = new StringBuilder();
-
+            classpath.append("\"");
             for (URL ele : this.classPathUrls) {
                 classpath = classpath
-                    .append(classpath.length() > 0 ? File.pathSeparator : "")
+                    .append(classpath.length() > 1 ? File.pathSeparator : "")
                     .append(new File(ele.toURI()));
             }
 
@@ -192,7 +192,7 @@ public class JavaProcessExecutor {
                 classpath.append(File.pathSeparator);
                 classpath.append(oldClasspath);
             }
-
+            classpath.append("\"");
             argsList.add(0, "-cp");
             argsList.add(1, classpath.toString());
 


### PR DESCRIPTION
Error Before: 

```
[DEBUG] Executing command :cmd.exe /X /C ""C:\Program Files\Java\jdk1.8.0_151\jre\bin\java.exe" -cp ;F:\Git\git-clone-share\target\classes;d:\.m2\rep
ository\io\vertx\vertx-core\3.5.3\vertx-core-3.5.3.jar;d:\.m2\repository\io\vertx\vertx-rx-java\3.5.3\vertx-rx-java-3.5.3.jar;d:\.m2\repository\io\ver
tx\vertx-web\3.5.3\vertx-web-3.5.3.jar;d:\.m2\repository\io\vertx\vertx-web-templ-freemarker\3.5.3\vertx-web-templ-freemarker-3.5.3.jar;d:\.m2\reposit
ory\io\vertx\vertx-jdbc-client\3.5.3\vertx-jdbc-client-3.5.3.jar;d:\.m2\repository\org\hsqldb\hsqldb\2.3.4\hsqldb-2.3.4.jar;d:\.m2\repository\ch\qos\l
ogback\logback-classic\1.2.3\logback-classic-1.2.3.jar;d:\.m2\repository\io\vertx\vertx-core\3.5.3\vertx-core-3.5.3.jar;d:\.m2\repository\io\netty\net
ty-common\4.1.19.Final\netty-common-4.1.19.Final.jar;d:\.m2\repository\io\netty\netty-buffer\4.1.19.Final\netty-buffer-4.1.19.Final.jar;d:\.m2\reposit
ory\io\netty\netty-transport\4.1.19.Final\netty-transport-4.1.19.Final.jar;d:\.m2\repository\io\netty\netty-handler\4.1.19.Final\netty-handler-4.1.19.
Final.jar;d:\.m2\repository\io\netty\netty-codec\4.1.19.Final\netty-codec-4.1.19.Final.jar;d:\.m2\repository\io\netty\netty-handler-proxy\4.1.19.Final
\netty-handler-proxy-4.1.19.Final.jar;d:\.m2\repository\io\netty\netty-codec-socks\4.1.19.Final\netty-codec-socks-4.1.19.Final.jar;d:\.m2\repository\i
o\netty\netty-codec-http\4.1.19.Final\netty-codec-http-4.1.19.Final.jar;d:\.m2\repository\io\netty\netty-codec-http2\4.1.19.Final\netty-codec-http2-4.
1.19.Final.jar;d:\.m2\repository\io\netty\netty-resolver\4.1.19.Final\netty-resolver-4.1.19.Final.jar;d:\.m2\repository\io\netty\netty-resolver-dns\4.
1.19.Final\netty-resolver-dns-4.1.19.Final.jar;d:\.m2\repository\io\netty\netty-codec-dns\4.1.19.Final\netty-codec-dns-4.1.19.Final.jar;d:\.m2\reposit
ory\com\fasterxml\jackson\core\jackson-core\2.9.5\jackson-core-2.9.5.jar;d:\.m2\repository\com\fasterxml\jackson\core\jackson-databind\2.9.5\jackson-d
atabind-2.9.5.jar;d:\.m2\repository\com\fasterxml\jackson\core\jackson-annotations\2.9.5\jackson-annotations-2.9.5.jar;d:\.m2\repository\io\vertx\vert
x-rx-java\3.5.3\vertx-rx-java-3.5.3.jar;d:\.m2\repository\io\reactivex\rxjava\1.3.5\rxjava-1.3.5.jar;d:\.m2\repository\io\vertx\vertx-web\3.5.3\vertx-
web-3.5.3.jar;d:\.m2\repository\io\vertx\vertx-auth-common\3.5.3\vertx-auth-common-3.5.3.jar;d:\.m2\repository\io\vertx\vertx-bridge-common\3.5.3\vert
x-bridge-common-3.5.3.jar;d:\.m2\repository\io\vertx\vertx-web-templ-freemarker\3.5.3\vertx-web-templ-freemarker-3.5.3.jar;d:\.m2\repository\org\freem
arker\freemarker\2.3.23\freemarker-2.3.23.jar;d:\.m2\repository\io\vertx\vertx-jdbc-client\3.5.3\vertx-jdbc-client-3.5.3.jar;d:\.m2\repository\io\vert
x\vertx-sql-common\3.5.3\vertx-sql-common-3.5.3.jar;d:\.m2\repository\com\mchange\c3p0\0.9.5.2\c3p0-0.9.5.2.jar;d:\.m2\repository\com\mchange\mchange-
commons-java\0.2.11\mchange-commons-java-0.2.11.jar;d:\.m2\repository\org\hsqldb\hsqldb\2.3.4\hsqldb-2.3.4.jar;d:\.m2\repository\ch\qos\logback\logbac
k-classic\1.2.3\logback-classic-1.2.3.jar;d:\.m2\repository\ch\qos\logback\logback-core\1.2.3\logback-core-1.2.3.jar;d:\.m2\repository\org\slf4j\slf4j
-api\1.7.25\slf4j-api-1.7.25.jar;D:\Program Files (x86)\apache-maven-3.5.0\bin\..\boot\plexus-classworlds-2.5.2.jar io.vertx.core.Launcher run com.gi
thub.abel533.git.GitHttpVerticle --redeploy=F:\Git\git-clone-share\target\classes/**/* --redeploy-scan-period=1000 redeploy-termination-period=1000 --
launcher-class="io.vertx.core.Launcher""
```

error path:

```
D:\Program Files (x86)\apache-maven-3.5.0\bin\..\boot\plexus-classworlds-2.5.2.jar
```

solution: add double quotes.

Correct command:

```shell
[DEBUG] Executing command :cmd.exe /X /C ""C:\Program Files\Java\jdk1.8.0_151\jre\bin\java.exe" -cp ";F:\Git\git-clone-share\target\classes;d:\.m2\rep
ository\io\vertx\vertx-core\3.5.3\vertx-core-3.5.3.jar;d:\.m2\repository\io\vertx\vertx-rx-java\3.5.3\vertx-rx-java-3.5.3.jar;d:\.m2\repository\io\ver
tx\vertx-web\3.5.3\vertx-web-3.5.3.jar;d:\.m2\repository\io\vertx\vertx-web-templ-freemarker\3.5.3\vertx-web-templ-freemarker-3.5.3.jar;d:\.m2\reposit
ory\io\vertx\vertx-jdbc-client\3.5.3\vertx-jdbc-client-3.5.3.jar;d:\.m2\repository\org\hsqldb\hsqldb\2.3.4\hsqldb-2.3.4.jar;d:\.m2\repository\ch\qos\l
ogback\logback-classic\1.2.3\logback-classic-1.2.3.jar;d:\.m2\repository\io\vertx\vertx-core\3.5.3\vertx-core-3.5.3.jar;d:\.m2\repository\io\netty\net
ty-common\4.1.19.Final\netty-common-4.1.19.Final.jar;d:\.m2\repository\io\netty\netty-buffer\4.1.19.Final\netty-buffer-4.1.19.Final.jar;d:\.m2\reposit
ory\io\netty\netty-transport\4.1.19.Final\netty-transport-4.1.19.Final.jar;d:\.m2\repository\io\netty\netty-handler\4.1.19.Final\netty-handler-4.1.19.
Final.jar;d:\.m2\repository\io\netty\netty-codec\4.1.19.Final\netty-codec-4.1.19.Final.jar;d:\.m2\repository\io\netty\netty-handler-proxy\4.1.19.Final
\netty-handler-proxy-4.1.19.Final.jar;d:\.m2\repository\io\netty\netty-codec-socks\4.1.19.Final\netty-codec-socks-4.1.19.Final.jar;d:\.m2\repository\i
o\netty\netty-codec-http\4.1.19.Final\netty-codec-http-4.1.19.Final.jar;d:\.m2\repository\io\netty\netty-codec-http2\4.1.19.Final\netty-codec-http2-4.
1.19.Final.jar;d:\.m2\repository\io\netty\netty-resolver\4.1.19.Final\netty-resolver-4.1.19.Final.jar;d:\.m2\repository\io\netty\netty-resolver-dns\4.
1.19.Final\netty-resolver-dns-4.1.19.Final.jar;d:\.m2\repository\io\netty\netty-codec-dns\4.1.19.Final\netty-codec-dns-4.1.19.Final.jar;d:\.m2\reposit
ory\com\fasterxml\jackson\core\jackson-core\2.9.5\jackson-core-2.9.5.jar;d:\.m2\repository\com\fasterxml\jackson\core\jackson-databind\2.9.5\jackson-d
atabind-2.9.5.jar;d:\.m2\repository\com\fasterxml\jackson\core\jackson-annotations\2.9.5\jackson-annotations-2.9.5.jar;d:\.m2\repository\io\vertx\vert
x-rx-java\3.5.3\vertx-rx-java-3.5.3.jar;d:\.m2\repository\io\reactivex\rxjava\1.3.5\rxjava-1.3.5.jar;d:\.m2\repository\io\vertx\vertx-web\3.5.3\vertx-
web-3.5.3.jar;d:\.m2\repository\io\vertx\vertx-auth-common\3.5.3\vertx-auth-common-3.5.3.jar;d:\.m2\repository\io\vertx\vertx-bridge-common\3.5.3\vert
x-bridge-common-3.5.3.jar;d:\.m2\repository\io\vertx\vertx-web-templ-freemarker\3.5.3\vertx-web-templ-freemarker-3.5.3.jar;d:\.m2\repository\org\freem
arker\freemarker\2.3.23\freemarker-2.3.23.jar;d:\.m2\repository\io\vertx\vertx-jdbc-client\3.5.3\vertx-jdbc-client-3.5.3.jar;d:\.m2\repository\io\vert
x\vertx-sql-common\3.5.3\vertx-sql-common-3.5.3.jar;d:\.m2\repository\com\mchange\c3p0\0.9.5.2\c3p0-0.9.5.2.jar;d:\.m2\repository\com\mchange\mchange-
commons-java\0.2.11\mchange-commons-java-0.2.11.jar;d:\.m2\repository\org\hsqldb\hsqldb\2.3.4\hsqldb-2.3.4.jar;d:\.m2\repository\ch\qos\logback\logbac
k-classic\1.2.3\logback-classic-1.2.3.jar;d:\.m2\repository\ch\qos\logback\logback-core\1.2.3\logback-core-1.2.3.jar;d:\.m2\repository\org\slf4j\slf4j
-api\1.7.25\slf4j-api-1.7.25.jar;D:\Program Files (x86)\apache-maven-3.5.0\bin\..\boot\plexus-classworlds-2.5.2.jar" io.vertx.core.Launcher run com.gi
thub.abel533.git.GitHttpVerticle --redeploy=F:\Git\git-clone-share\target\classes/**/* --redeploy-scan-period=1000 redeploy-termination-period=1000 --
launcher-class="io.vertx.core.Launcher""
```