### PR TITLE
Upgrade to latest Vert.x version 3.5.4

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -8,6 +8,9 @@ trim_trailing_whitespace = true
 end_of_line = lf
 insert_final_newline = true
 
+[.gitignore]
+end_of_line = crlf
+
 [Makefile]
 indent_style = tab
 

--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,9 @@ buildNumber.properties
 .settings/
 .classpath
 
+# Shell script logs
+*.log
+
 ### Java template
 *.class
 

--- a/pom.xml
+++ b/pom.xml
@@ -114,7 +114,7 @@
         <shrinkwrap.version>1.2.6</shrinkwrap.version>
 
         <!-- Test dependency versions -->
-        <vertx-core.version>3.5.3</vertx-core.version>
+        <vertx-core.version>3.5.4</vertx-core.version>
         <assertj-core.version>3.11.1</assertj-core.version>
         <junit.version>4.12</junit.version>
         <maven-verifier.version>1.6</maven-verifier.version>

--- a/samples/custom-launcher-example/pom.xml
+++ b/samples/custom-launcher-example/pom.xml
@@ -25,7 +25,7 @@
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <vertx.version>3.5.3</vertx.version>
+        <vertx.version>3.5.4</vertx.version>
         <vertx.launcher>org.vertx.demo.MyLauncher</vertx.launcher>
         <vertx.verticle>org.vertx.demo.MainVerticle</vertx.verticle>
     </properties>

--- a/samples/custom-main-example/pom.xml
+++ b/samples/custom-main-example/pom.xml
@@ -25,7 +25,7 @@
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <vertx.version>3.5.3</vertx.version>
+        <vertx.version>3.5.4</vertx.version>
         <vertx.launcher>org.vertx.demo.MyMain</vertx.launcher>
     </properties>
 

--- a/samples/frontend-example/pom.xml
+++ b/samples/frontend-example/pom.xml
@@ -25,7 +25,7 @@
     <packaging>jar</packaging>
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <vertx.version>3.5.3</vertx.version>
+        <vertx.version>3.5.4</vertx.version>
         <vertx.verticle>io.vertx.demo.MyVerticle</vertx.verticle>
         <node_modules.path>${project.build.directory}/node_modules</node_modules.path>
     </properties>

--- a/samples/java-redeploy-example/pom.xml
+++ b/samples/java-redeploy-example/pom.xml
@@ -25,7 +25,7 @@
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <vertx.version>3.5.3</vertx.version>
+        <vertx.version>3.5.4</vertx.version>
         <vertx.verticle>org.vertx.demo.MainVerticle</vertx.verticle>
     </properties>
 

--- a/samples/kotlin-example/pom.xml
+++ b/samples/kotlin-example/pom.xml
@@ -31,8 +31,7 @@
         <kotlin.version>1.2.60</kotlin.version>
         <kotlin.compiler.incremental>true</kotlin.compiler.incremental>
         <kotlin.compiler.jvmTarget>1.8</kotlin.compiler.jvmTarget>
-
-        <vertx.version>3.5.3</vertx.version>
+        <vertx.version>3.5.4</vertx.version>
         <vertx.verticle>org.vertx.demo.MyKotlinVerticle</vertx.verticle>
     </properties>
 


### PR DESCRIPTION
This PR updates the vert.x core version so that the archetype generates a project with the latest one.   

(It also adds the log files created by the release shell scripts to `.gitignore`, preserving its Windows EOL convention)