### PR TITLE
Remove redundant sourceDirectory config

### DIFF
--- a/samples/kotlin-example/pom.xml
+++ b/samples/kotlin-example/pom.xml
@@ -36,7 +36,7 @@
     </properties>
 
     <build>
-        <sourceDirectory>${project.basedir}/src/main/kotlin</sourceDirectory>
+        <!--    <sourceDirectory>${project.basedir}/src/main/kotlin</sourceDirectory>-->
         <plugins>
             <plugin>
                 <groupId>io.reactiverse</groupId>


### PR DESCRIPTION
this line should be redundant 
   <sourceDirectory>${project.basedir}/src/main/kotlin</sourceDirectory>
since if we keep this line of config here, and if we want to mix it with java
<sourceDir>${project.basedir}/src/main/java</sourceDir>//this line won't work
after compared to my config example, it seems like this line is redundant and should be comment out
<sourceDirectory>${project.basedir}/src/main/kotlin</sourceDirectory>
after comment out the line, execute mvn:package the java file will be compiled and copied to the jar and target/classes directory