### PR TITLE
Make Vert.x BOM value configurable in SetupMojo

### DIFF
--- a/src/it/setup-with-diff-vertx-bom-it/invoker.properties
+++ b/src/it/setup-with-diff-vertx-bom-it/invoker.properties
@@ -1,0 +1,16 @@
+#
+#    Copyright (c) 2016-2021 Red Hat, Inc.
+#
+#    Red Hat licenses this file to you under the Apache License, version
+#    2.0 (the "License"); you may not use this file except in compliance
+#    with the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS,
+#    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+#    implied.  See the License for the specific language governing
+#    permissions and limitations under the License.
+#
+invoker.goals=${project.groupId}:${project.artifactId}:${project.version}:setup -DvertxBom=vertx-dependencies

--- a/src/it/setup-with-diff-vertx-bom-it/pom.xml
+++ b/src/it/setup-with-diff-vertx-bom-it/pom.xml
@@ -1,0 +1,49 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~
+  ~   Copyright (c) 2016-2021 Red Hat, Inc.
+  ~
+  ~   Red Hat licenses this file to you under the Apache License, version
+  ~   2.0 (the "License"); you may not use this file except in compliance
+  ~   with the License.  You may obtain a copy of the License at
+  ~
+  ~      http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~   Unless required by applicable law or agreed to in writing, software
+  ~   distributed under the License is distributed on an "AS IS" BASIS,
+  ~   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+  ~   implied.  See the License for the specific language governing
+  ~   permissions and limitations under the License.
+  -->
+
+<project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://maven.apache.org/POM/4.0.0"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <groupId>org.vertx.demo</groupId>
+    <artifactId>vertx-setup-demo</artifactId>
+    <version>0.1-SNAPSHOT</version>
+    <packaging>jar</packaging>
+    <build>
+        <plugins>
+            <plugin>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <version>3.8.1</version>
+                <configuration>
+                    <source>1.8</source>
+                    <target>1.8</target>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+    <properties>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    </properties>
+    <dependencies>
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <version>4.13.1</version>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+</project>

--- a/src/it/setup-with-diff-vertx-bom-it/verify.groovy
+++ b/src/it/setup-with-diff-vertx-bom-it/verify.groovy
@@ -1,0 +1,23 @@
+/*
+ *    Copyright (c) 2016-2021 Red Hat, Inc.
+ *
+ *    Red Hat licenses this file to you under the Apache License, version
+ *    2.0 (the "License"); you may not use this file except in compliance
+ *    with the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ *    implied.  See the License for the specific language governing
+ *    permissions and limitations under the License.
+ */
+
+
+import io.reactiverse.vertx.maven.plugin.Verify
+
+String base = basedir
+File pomFile = new File(base, "pom.xml")
+
+Verify.verifySetupWithBom(pomFile)

--- a/src/main/java/io/reactiverse/vertx/maven/plugin/mojos/SetupMojo.java
+++ b/src/main/java/io/reactiverse/vertx/maven/plugin/mojos/SetupMojo.java
@@ -50,6 +50,8 @@ public class SetupMojo extends AbstractMojo {
     public static final String JAVA_EXTENSION = ".java";
     public static final String VERTX_CORE_VERSION = "vertx-core-version";
     public static final String VERTX_GROUP_ID = "io.vertx";
+    public static final String VERTX_BOM_ARTIFACTID = "vertx-stack-depchain";
+
     private final String PLUGIN_GROUPID = "io.reactiverse";
     private final String PLUGIN_ARTIFACTID = "vertx-maven-plugin";
     private final String VERTX_MAVEN_PLUGIN_VERSION_PROPERTY = "vertx-maven-plugin-version";
@@ -68,6 +70,9 @@ public class SetupMojo extends AbstractMojo {
 
     @Parameter(property = "projectVersion", defaultValue = "1.0-SNAPSHOT")
     protected String projectVersion;
+
+    @Parameter(property = "vertxBom", defaultValue = VERTX_BOM_ARTIFACTID)
+    protected String vertxBom;
 
     @Parameter(property = "vertxVersion")
     protected String vertxVersion;
@@ -214,6 +219,7 @@ public class SetupMojo extends AbstractMojo {
             context.put("mProjectGroupId", projectGroupId);
             context.put("mProjectArtifactId", projectArtifactId);
             context.put("mProjectVersion", projectVersion);
+            context.put("vertxBom", vertxBom != null ? vertxBom : VERTX_BOM_ARTIFACTID);
             context.put("vertxVersion", vertxVersion != null ? vertxVersion : MojoUtils.getVersion(VERTX_CORE_VERSION));
 
             context.put("vertxVerticle", verticle);
@@ -350,22 +356,22 @@ public class SetupMojo extends AbstractMojo {
 
 
     /**
-     * Method used to add the vert.x "vertx-stack-depchain" BOM
+     * Method used to add the vert.x BOM
      *
      * @param model - the {@code {@link Model}}
      */
     private void addVertxBom(Model model) {
-        Dependency vertxBom = dependency(VERTX_GROUP_ID, "vertx-stack-depchain", "${vertx.version}");
-        vertxBom.setType("pom");
-        vertxBom.setScope("import");
+        Dependency dependency = dependency(VERTX_GROUP_ID, vertxBom, "${vertx.version}");
+        dependency.setType("pom");
+        dependency.setScope("import");
 
         if (model.getDependencyManagement() != null) {
-            if (!MojoUtils.hasDependency(project, VERTX_GROUP_ID, "vertx-stack-depchain")) {
-                model.getDependencyManagement().addDependency(vertxBom);
+            if (!MojoUtils.hasDependency(project, VERTX_GROUP_ID, vertxBom)) {
+                model.getDependencyManagement().addDependency(dependency);
             }
         } else {
             DependencyManagement dm = new DependencyManagement();
-            dm.addDependency(vertxBom);
+            dm.addDependency(dependency);
             model.setDependencyManagement(dm);
         }
     }

--- a/src/main/resources/templates/pom-template.ftl
+++ b/src/main/resources/templates/pom-template.ftl
@@ -18,7 +18,7 @@
         <dependencies>
             <dependency>
                 <groupId>io.vertx</groupId>
-                <artifactId>vertx-stack-depchain</artifactId>
+                <artifactId>${vertxBom}</artifactId>
                 <version>${r"${vertx.version}"}</version>
                 <type>pom</type>
                 <scope>import</scope>

--- a/src/test/java/io/reactiverse/vertx/maven/plugin/SetupMojoTest.java
+++ b/src/test/java/io/reactiverse/vertx/maven/plugin/SetupMojoTest.java
@@ -27,6 +27,7 @@ import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugin.logging.Log;
 import org.apache.maven.project.MavenProject;
 import org.codehaus.plexus.util.xml.Xpp3Dom;
+import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -46,6 +47,11 @@ public class SetupMojoTest {
     public void setUp() {
         File junk = new File("target/junk");
         FileUtils.deleteQuietly(junk);
+    }
+
+    @After
+    public void tearDown() throws Exception {
+        System.clearProperty("vertxVersion");
     }
 
     @Test
@@ -275,7 +281,7 @@ public class SetupMojoTest {
     }
 
     @Test
-    public void testVerticleCreatPom() throws Exception {
+    public void testVerticleCreatePom() throws Exception {
 
         new File("target/unit/nopom").mkdirs();
 

--- a/src/test/java/io/reactiverse/vertx/maven/plugin/SetupMojoTest.java
+++ b/src/test/java/io/reactiverse/vertx/maven/plugin/SetupMojoTest.java
@@ -287,6 +287,7 @@ public class SetupMojoTest {
         tplContext.put("mProjectGroupId", "com.example.vertx");
         tplContext.put("mProjectArtifactId", "vertx-example");
         tplContext.put("mProjectVersion", "1.0-SNAPSHOT");
+        tplContext.put("vertxBom", "vertx-stack-depchain");
         tplContext.put("vertxVersion", vertxVersion);
         tplContext.put("vertxVerticle", "com.example.vertx.MainVerticle");
         tplContext.put("vmpVersion", MojoUtils.getVersion("vertx-maven-plugin-version"));


### PR DESCRIPTION
Users can switch from `vertx-stack-depchain` to `vertx-dependencies` with:

```
mvn io.reactiverse:vertx-maven-plugin:1.0-SNAPSHOT:setup -DvertxBom=vertx-dependencies
```