### PR TITLE
Migrate all tests and docs to Vert.x 4

### DIFF
--- a/samples/custom-launcher-example/pom.xml
+++ b/samples/custom-launcher-example/pom.xml
@@ -25,7 +25,7 @@
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <vertx.version>4.0.2</vertx.version>
+        <vertx.version>4.0.3</vertx.version>
         <vertx.launcher>org.vertx.demo.MyLauncher</vertx.launcher>
         <vertx.verticle>org.vertx.demo.MainVerticle</vertx.verticle>
     </properties>

--- a/samples/custom-main-example/pom.xml
+++ b/samples/custom-main-example/pom.xml
@@ -25,7 +25,7 @@
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <vertx.version>4.0.2</vertx.version>
+        <vertx.version>4.0.3</vertx.version>
         <vertx.launcher>org.vertx.demo.MyMain</vertx.launcher>
     </properties>
 

--- a/samples/frontend-example/pom.xml
+++ b/samples/frontend-example/pom.xml
@@ -25,7 +25,7 @@
     <packaging>jar</packaging>
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <vertx.version>4.0.2</vertx.version>
+        <vertx.version>4.0.3</vertx.version>
         <vertx.verticle>io.vertx.demo.MyVerticle</vertx.verticle>
         <node_modules.path>${project.build.directory}/node_modules</node_modules.path>
     </properties>

--- a/samples/java-redeploy-example/pom.xml
+++ b/samples/java-redeploy-example/pom.xml
@@ -25,7 +25,7 @@
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <vertx.version>4.0.2</vertx.version>
+        <vertx.version>4.0.3</vertx.version>
         <vertx.verticle>org.vertx.demo.MainVerticle</vertx.verticle>
     </properties>
 

--- a/samples/kotlin-example/pom.xml
+++ b/samples/kotlin-example/pom.xml
@@ -31,7 +31,7 @@
         <kotlin.version>1.2.60</kotlin.version>
         <kotlin.compiler.incremental>true</kotlin.compiler.incremental>
         <kotlin.compiler.jvmTarget>1.8</kotlin.compiler.jvmTarget>
-        <vertx.version>4.0.2</vertx.version>
+        <vertx.version>4.0.3</vertx.version>
         <vertx.verticle>org.vertx.demo.MyKotlinVerticle</vertx.verticle>
     </properties>
 

--- a/src/it/help-it/pom.xml
+++ b/src/it/help-it/pom.xml
@@ -25,7 +25,7 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <vertx.version>3.4.2</vertx.version>
+        <vertx.version>4.0.3</vertx.version>
         <vertx.verticle>org.vertx.demo.MainVerticle</vertx.verticle>
     </properties>
     <build>

--- a/src/it/package-archive-all-it/pom.xml
+++ b/src/it/package-archive-all-it/pom.xml
@@ -25,7 +25,7 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <vertx.version>3.4.2</vertx.version>
+        <vertx.version>4.0.3</vertx.version>
         <vertx.verticle>org.vertx.demo.MainVerticle</vertx.verticle>
     </properties>
     <build>

--- a/src/it/package-archive-all-it/verify.groovy
+++ b/src/it/package-archive-all-it/verify.groovy
@@ -31,4 +31,3 @@ Verify.verifyNotContain(primaryArtifactFile, "Log4j-config.dtd")
 Verify.verifyNotContain(primaryArtifactFile, "Log4j-events.dtd")
 
 Verify.verifyContains(primaryArtifactFile,"META-INF/services/com.fasterxml.jackson.core.JsonFactory")
-Verify.verifyContains(primaryArtifactFile,"META-INF/services/io.vertx.core.spi.FutureFactory")

--- a/src/it/package-archive-combination-it/package-spi-deps-order-it/pom.xml
+++ b/src/it/package-archive-combination-it/package-spi-deps-order-it/pom.xml
@@ -27,7 +27,7 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <vertx.version>3.3.0</vertx.version>
+        <vertx.version>4.0.3</vertx.version>
         <vertx.verticle>org.vertx.demo.MainVerticle</vertx.verticle>
     </properties>
     <build>

--- a/src/it/package-archive-combination-it/package-spi-deps-order2-it/pom.xml
+++ b/src/it/package-archive-combination-it/package-spi-deps-order2-it/pom.xml
@@ -27,7 +27,7 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <vertx.version>3.3.0</vertx.version>
+        <vertx.version>4.0.3</vertx.version>
         <vertx.verticle>org.vertx.demo.MainVerticle</vertx.verticle>
     </properties>
     <build>

--- a/src/it/package-archive-dependencies-it/pom.xml
+++ b/src/it/package-archive-dependencies-it/pom.xml
@@ -25,7 +25,7 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <vertx.version>3.4.2</vertx.version>
+        <vertx.version>4.0.3</vertx.version>
         <vertx.verticle>org.vertx.demo.MainVerticle</vertx.verticle>
     </properties>
     <build>

--- a/src/it/package-archive-file-inclusion-it/pom.xml
+++ b/src/it/package-archive-file-inclusion-it/pom.xml
@@ -25,7 +25,7 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <vertx.version>3.4.2</vertx.version>
+        <vertx.version>4.0.3</vertx.version>
         <vertx.verticle>org.vertx.demo.MainVerticle</vertx.verticle>
     </properties>
     <build>

--- a/src/it/package-archive-fileset-it/pom.xml
+++ b/src/it/package-archive-fileset-it/pom.xml
@@ -25,7 +25,7 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <vertx.version>3.4.2</vertx.version>
+        <vertx.version>4.0.3</vertx.version>
         <vertx.verticle>org.vertx.demo.MainVerticle</vertx.verticle>
     </properties>
     <build>

--- a/src/it/package-archive-include-classes-it/pom.xml
+++ b/src/it/package-archive-include-classes-it/pom.xml
@@ -25,7 +25,7 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <vertx.version>3.4.2</vertx.version>
+        <vertx.version>4.0.3</vertx.version>
         <vertx.verticle>org.vertx.demo.MainVerticle</vertx.verticle>
     </properties>
     <build>

--- a/src/it/package-archive-it/pom.xml
+++ b/src/it/package-archive-it/pom.xml
@@ -25,7 +25,7 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <vertx.version>3.4.2</vertx.version>
+        <vertx.version>4.0.3</vertx.version>
         <vertx.verticle>org.vertx.demo.MainVerticle</vertx.verticle>
     </properties>
     <build>

--- a/src/it/package-archive-manifest-it/pom.xml
+++ b/src/it/package-archive-manifest-it/pom.xml
@@ -25,7 +25,7 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <vertx.version>3.4.2</vertx.version>
+        <vertx.version>4.0.3</vertx.version>
         <vertx.verticle>org.vertx.demo.MainVerticle</vertx.verticle>
     </properties>
     <build>

--- a/src/it/package-archive-no-jar-it/pom.xml
+++ b/src/it/package-archive-no-jar-it/pom.xml
@@ -25,7 +25,7 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <vertx.version>3.4.2</vertx.version>
+        <vertx.version>4.0.3</vertx.version>
         <vertx.verticle>org.vertx.demo.MainVerticle</vertx.verticle>
     </properties>
     <build>

--- a/src/it/package-it/pom.xml
+++ b/src/it/package-it/pom.xml
@@ -25,7 +25,7 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <vertx.version>3.4.2</vertx.version>
+        <vertx.version>4.0.3</vertx.version>
         <vertx.verticle>org.vertx.demo.MainVerticle</vertx.verticle>
     </properties>
     <build>

--- a/src/it/package-log4j2-plugin-it/pom.xml
+++ b/src/it/package-log4j2-plugin-it/pom.xml
@@ -25,7 +25,7 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <vertx.version>3.4.2</vertx.version>
+        <vertx.version>4.0.3</vertx.version>
         <vertx.launcher>org.vertx.demo.Main</vertx.launcher>
     </properties>
     <build>

--- a/src/it/package-no-jar-it/pom.xml
+++ b/src/it/package-no-jar-it/pom.xml
@@ -25,7 +25,7 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <vertx.version>3.4.2</vertx.version>
+        <vertx.version>4.0.3</vertx.version>
         <vertx.verticle>org.vertx.demo.MainVerticle</vertx.verticle>
     </properties>
     <build>

--- a/src/it/package-nofinal-name-it/pom.xml
+++ b/src/it/package-nofinal-name-it/pom.xml
@@ -26,7 +26,7 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <vertx.version>3.4.2</vertx.version>
+        <vertx.version>4.0.3</vertx.version>
         <vertx.verticle>org.vertx.demo.MainVerticle</vertx.verticle>
     </properties>
     <build>

--- a/src/it/package-spi-it/pom.xml
+++ b/src/it/package-spi-it/pom.xml
@@ -25,7 +25,7 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <vertx.version>3.3.0</vertx.version>
+        <vertx.version>4.0.3</vertx.version>
         <vertx.verticle>org.vertx.demo.MainVerticle</vertx.verticle>
     </properties>
     <build>

--- a/src/it/package-spi-order-combination-it/package-spi-deps-order-it/pom.xml
+++ b/src/it/package-spi-order-combination-it/package-spi-deps-order-it/pom.xml
@@ -27,7 +27,7 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <vertx.version>3.3.0</vertx.version>
+        <vertx.version>4.0.3</vertx.version>
         <vertx.verticle>org.vertx.demo.MainVerticle</vertx.verticle>
     </properties>
     <build>

--- a/src/it/package-spi-order-combination-it/package-spi-deps-order2-it/pom.xml
+++ b/src/it/package-spi-order-combination-it/package-spi-deps-order2-it/pom.xml
@@ -27,7 +27,7 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <vertx.version>3.3.0</vertx.version>
+        <vertx.version>4.0.3</vertx.version>
         <vertx.verticle>org.vertx.demo.MainVerticle</vertx.verticle>
     </properties>
     <build>

--- a/src/it/package-with-classifier-it/pom.xml
+++ b/src/it/package-with-classifier-it/pom.xml
@@ -25,7 +25,7 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <vertx.version>3.4.2</vertx.version>
+        <vertx.version>4.0.3</vertx.version>
         <vertx.verticle>org.vertx.demo.MainVerticle</vertx.verticle>
     </properties>
     <build>

--- a/src/it/package-withfinal-name-it/pom.xml
+++ b/src/it/package-withfinal-name-it/pom.xml
@@ -26,7 +26,7 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <vertx.version>3.4.2</vertx.version>
+        <vertx.version>4.0.3</vertx.version>
         <vertx.verticle>org.vertx.demo.MainVerticle</vertx.verticle>
     </properties>
     <build>

--- a/src/it/run-args-custom-launcher-it/pom.xml
+++ b/src/it/run-args-custom-launcher-it/pom.xml
@@ -24,7 +24,7 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <vertx.version>3.4.2</vertx.version>
+        <vertx.version>4.0.3</vertx.version>
     </properties>
     <build>
         <plugins>

--- a/src/it/run-args-extended-launcher-it/pom.xml
+++ b/src/it/run-args-extended-launcher-it/pom.xml
@@ -24,7 +24,7 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <vertx.version>3.4.2</vertx.version>
+        <vertx.version>4.0.3</vertx.version>
     </properties>
     <build>
         <plugins>

--- a/src/it/run-args-extended-launcher-it/src/main/java/demo/SimpleVerticle.java
+++ b/src/it/run-args-extended-launcher-it/src/main/java/demo/SimpleVerticle.java
@@ -18,7 +18,7 @@
 package demo;
 
 import io.vertx.core.AbstractVerticle;
-import io.vertx.core.Future;
+import io.vertx.core.Promise;
 
 public class SimpleVerticle extends AbstractVerticle {
     @Override

--- a/src/it/run-cluster-defaults-it/pom.xml
+++ b/src/it/run-cluster-defaults-it/pom.xml
@@ -24,7 +24,7 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <vertx.version>3.4.2</vertx.version>
+        <vertx.version>4.0.3</vertx.version>
         <vertx.verticle>org.vertx.demo.SimpleVerticle</vertx.verticle>
     </properties>
     <build>

--- a/src/it/run-cluster-defaults-it/src/main/java/org/vertx/demo/SimpleVerticle.java
+++ b/src/it/run-cluster-defaults-it/src/main/java/org/vertx/demo/SimpleVerticle.java
@@ -18,7 +18,7 @@
 package org.vertx.demo;
 
 import io.vertx.core.AbstractVerticle;
-import io.vertx.core.Future;
+import io.vertx.core.Promise;
 
 /**
  * @author kameshs

--- a/src/it/run-config-it/pom.xml
+++ b/src/it/run-config-it/pom.xml
@@ -25,7 +25,7 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <vertx.version>3.4.2</vertx.version>
+        <vertx.version>4.0.3</vertx.version>
         <vertx.verticle>org.vertx.demo.SimpleVerticle</vertx.verticle>
     </properties>
     <build>

--- a/src/it/run-config-it/src/main/java/org/vertx/demo/SimpleVerticle.java
+++ b/src/it/run-config-it/src/main/java/org/vertx/demo/SimpleVerticle.java
@@ -18,14 +18,14 @@
 package org.vertx.demo;
 
 import io.vertx.core.AbstractVerticle;
-import io.vertx.core.Future;
+import io.vertx.core.Promise;
 
 /**
  * @author kameshs
  */
 public class SimpleVerticle extends AbstractVerticle {
     @Override
-    public void start(Future<Void> startFuture) throws Exception {
+    public void start(Promise<Void> startFuture) throws Exception {
         int httpPort = config().getInteger("http.port");
         System.out.println("Configured HTTP Port is :" + httpPort);
         startFuture.complete();

--- a/src/it/run-config-param-it/pom.xml
+++ b/src/it/run-config-param-it/pom.xml
@@ -25,7 +25,7 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <vertx.version>3.4.2</vertx.version>
+        <vertx.version>4.0.3</vertx.version>
         <vertx.verticle>org.vertx.demo.SimpleVerticle</vertx.verticle>
     </properties>
     <build>

--- a/src/it/run-config-param-it/src/main/java/org/vertx/demo/SimpleVerticle.java
+++ b/src/it/run-config-param-it/src/main/java/org/vertx/demo/SimpleVerticle.java
@@ -18,14 +18,14 @@
 package org.vertx.demo;
 
 import io.vertx.core.AbstractVerticle;
-import io.vertx.core.Future;
+import io.vertx.core.Promise;
 
 /**
  * @author kameshs
  */
 public class SimpleVerticle extends AbstractVerticle {
     @Override
-    public void start(Future<Void> startFuture) throws Exception {
+    public void start(Promise<Void> startFuture) throws Exception {
         int httpPort = config().getInteger("http.port");
         System.out.println("Configured HTTP Port is :" + httpPort);
         startFuture.complete();

--- a/src/it/run-ha-defaults-it/pom.xml
+++ b/src/it/run-ha-defaults-it/pom.xml
@@ -24,7 +24,7 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <vertx.version>3.4.2</vertx.version>
+        <vertx.version>4.0.3</vertx.version>
         <vertx.verticle>org.vertx.demo.SimpleVerticle</vertx.verticle>
     </properties>
     <build>
@@ -51,6 +51,7 @@
                         <configuration>
                             <runArgs>
                                 <runArg>--ha</runArg>
+                                <runArg>-Djava.net.preferIPv4Stack=true</runArg>
                             </runArgs>
                         </configuration>
                     </execution>
@@ -65,7 +66,7 @@
         </dependency>
         <dependency>
             <groupId>io.vertx</groupId>
-            <artifactId>vertx-jgroups</artifactId>
+            <artifactId>vertx-infinispan</artifactId>
         </dependency>
     </dependencies>
     <dependencyManagement>

--- a/src/it/run-ha-defaults-it/src/main/java/org/vertx/demo/SimpleVerticle.java
+++ b/src/it/run-ha-defaults-it/src/main/java/org/vertx/demo/SimpleVerticle.java
@@ -18,14 +18,14 @@
 package org.vertx.demo;
 
 import io.vertx.core.AbstractVerticle;
-import io.vertx.core.Future;
+import io.vertx.core.Promise;
 
 /**
  * @author kameshs
  */
 public class SimpleVerticle extends AbstractVerticle {
     @Override
-    public void start(Future<Void> startFuture) throws Exception {
+    public void start(Promise<Void> startFuture) throws Exception {
        startFuture.complete();
        vertx.close();
        System.exit(0);

--- a/src/it/run-ha-defaults-it/verify.groovy
+++ b/src/it/run-ha-defaults-it/verify.groovy
@@ -18,7 +18,7 @@ String base = basedir
 def file = new File(base, "build.log")
 assert file.exists()
 assert file.text.contains("Starting clustering...")
-assert file.text.contains("io.vertx.spi.cluster.jgroups.JGroupsClusterManager")
+assert file.text.contains("io.vertx.ext.cluster.infinispan.InfinispanClusterManager")
 assert file.text.contains("io.vertx.core.impl.HAManager")
 assert file.text.contains("A quorum has been obtained. Any deploymentIDs waiting on a quorum will now be deployed")
 

--- a/src/it/run-ha-group-it/pom.xml
+++ b/src/it/run-ha-group-it/pom.xml
@@ -24,7 +24,7 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <vertx.version>3.4.2</vertx.version>
+        <vertx.version>4.0.3</vertx.version>
         <vertx.verticle>demo.SimpleVerticle</vertx.verticle>
     </properties>
     <build>
@@ -54,6 +54,7 @@
                     <runArgs>
                         <runArg>--ha</runArg>
                         <runArg>--hagroup="demo"</runArg>
+                        <runArg>-Djava.net.preferIPv4Stack=true</runArg>
                     </runArgs>
                 </configuration>
             </plugin>
@@ -66,7 +67,7 @@
         </dependency>
         <dependency>
             <groupId>io.vertx</groupId>
-            <artifactId>vertx-jgroups</artifactId>
+            <artifactId>vertx-infinispan</artifactId>
         </dependency>
     </dependencies>
     <dependencyManagement>

--- a/src/it/run-ha-group-it/src/main/java/demo/SimpleVerticle.java
+++ b/src/it/run-ha-group-it/src/main/java/demo/SimpleVerticle.java
@@ -17,7 +17,7 @@
 package demo;
 
 import io.vertx.core.AbstractVerticle;
-import io.vertx.core.Future;
+import io.vertx.core.Promise;
 
 import java.util.List;
 import java.util.Optional;

--- a/src/it/run-ha-group-it/verify.groovy
+++ b/src/it/run-ha-group-it/verify.groovy
@@ -19,7 +19,7 @@ def file = new File(base, "build.log")
 String strLog = file.text
 assert file.exists()
 assert strLog.contains("Starting clustering...")
-assert strLog.contains("io.vertx.spi.cluster.jgroups.JGroupsClusterManager")
+assert strLog.contains("io.vertx.ext.cluster.infinispan.InfinispanClusterManager")
 assert strLog.contains("io.vertx.core.impl.HAManager")
 assert strLog.contains("A quorum has been obtained. Any deploymentIDs waiting on a quorum will now be deployed")
 assert strLog ==~ /(?ms)^.*HA\s?Group="?demo"?.*$/

--- a/src/it/run-ha-quorum-it/pom.xml
+++ b/src/it/run-ha-quorum-it/pom.xml
@@ -24,7 +24,7 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <vertx.version>3.4.2</vertx.version>
+        <vertx.version>4.0.3</vertx.version>
         <vertx.verticle>demo.SimpleVerticle</vertx.verticle>
     </properties>
     <build>
@@ -54,6 +54,7 @@
                     <runArgs>
                         <runArg>--ha</runArg>
                         <runArg>quorum=2</runArg>
+                        <runArg>-Djava.net.preferIPv4Stack=true</runArg>
                     </runArgs>
                 </configuration>
             </plugin>
@@ -66,7 +67,7 @@
         </dependency>
         <dependency>
             <groupId>io.vertx</groupId>
-            <artifactId>vertx-jgroups</artifactId>
+            <artifactId>vertx-infinispan</artifactId>
         </dependency>
     </dependencies>
     <dependencyManagement>

--- a/src/it/run-ha-quorum-it/src/main/java/demo/SimpleVerticle.java
+++ b/src/it/run-ha-quorum-it/src/main/java/demo/SimpleVerticle.java
@@ -17,7 +17,7 @@
 package demo;
 
 import io.vertx.core.AbstractVerticle;
-import io.vertx.core.Future;
+import io.vertx.core.Promise;
 
 import java.util.List;
 import java.util.Optional;

--- a/src/it/run-ha-quorum-it/verify.groovy
+++ b/src/it/run-ha-quorum-it/verify.groovy
@@ -19,7 +19,7 @@ def file = new File(base, "build.log")
 String strLog = file.text
 assert file.exists()
 assert strLog.contains("Starting clustering...")
-assert strLog.contains("io.vertx.spi.cluster.jgroups.JGroupsClusterManager")
+assert strLog.contains("io.vertx.ext.cluster.infinispan.InfinispanClusterManager")
 assert strLog.contains("io.vertx.core.impl.HAManager")
 assert strLog.contains("A quorum has been obtained. Any deploymentIDs waiting on a quorum will now be deployed")
 assert strLog ==~ /(?ms)^.*Quorum=2.*$/

--- a/src/it/run-it/pom.xml
+++ b/src/it/run-it/pom.xml
@@ -25,7 +25,7 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <vertx.version>3.4.2</vertx.version>
+        <vertx.version>4.0.3</vertx.version>
         <vertx.verticle>org.vertx.demo.SimpleVerticle</vertx.verticle>
     </properties>
     <build>

--- a/src/it/run-it/src/main/java/org/vertx/demo/SimpleVerticle.java
+++ b/src/it/run-it/src/main/java/org/vertx/demo/SimpleVerticle.java
@@ -18,14 +18,14 @@
 package org.vertx.demo;
 
 import io.vertx.core.AbstractVerticle;
-import io.vertx.core.Future;
+import io.vertx.core.Promise;
 
 /**
  * @author kameshs
  */
 public class SimpleVerticle extends AbstractVerticle {
     @Override
-    public void start(Future<Void> startFuture) throws Exception {
+    public void start(Promise<Void> startFuture) throws Exception {
         startFuture.complete();
 
         vertx.close();

--- a/src/it/run-options-it/pom.xml
+++ b/src/it/run-options-it/pom.xml
@@ -25,7 +25,7 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <vertx.version>3.8.0</vertx.version>
+        <vertx.version>4.0.3</vertx.version>
         <vertx.verticle>org.vertx.demo.SimpleVerticle</vertx.verticle>
     </properties>
     <build>

--- a/src/it/run-redeploy-it/pom.xml
+++ b/src/it/run-redeploy-it/pom.xml
@@ -25,7 +25,7 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <vertx.version>3.4.2</vertx.version>
+        <vertx.version>4.0.3</vertx.version>
         <vertx.verticle>org.vertx.demo.SimpleVerticle</vertx.verticle>
         <vertx.launcher>org.vertx.demo.MyLauncher</vertx.launcher>
     </properties>

--- a/src/it/run-redeploy-it/src/main/java/org/vertx/demo/SimpleVerticle.java
+++ b/src/it/run-redeploy-it/src/main/java/org/vertx/demo/SimpleVerticle.java
@@ -18,14 +18,14 @@
 package org.vertx.demo;
 
 import io.vertx.core.AbstractVerticle;
-import io.vertx.core.Future;
+import io.vertx.core.Promise;
 
 /**
  * @author kameshs
  */
 public class SimpleVerticle extends AbstractVerticle {
     @Override
-    public void start(Future<Void> startFuture) throws Exception {
+    public void start(Promise<Void> startFuture) throws Exception {
        startFuture.complete();
        vertx.close();
        System.exit(0);

--- a/src/it/run-with-jvmArgs-it/pom.xml
+++ b/src/it/run-with-jvmArgs-it/pom.xml
@@ -25,7 +25,7 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <vertx.version>3.4.2</vertx.version>
+        <vertx.version>4.0.3</vertx.version>
         <vertx.verticle>org.vertx.demo.SimpleVerticle</vertx.verticle>
     </properties>
     <build>

--- a/src/it/run-with-jvmArgs-it/src/main/java/org/vertx/demo/SimpleVerticle.java
+++ b/src/it/run-with-jvmArgs-it/src/main/java/org/vertx/demo/SimpleVerticle.java
@@ -18,7 +18,7 @@
 package org.vertx.demo;
 
 import io.vertx.core.AbstractVerticle;
-import io.vertx.core.Future;
+import io.vertx.core.Promise;
 
 /**
  * @author kameshs

--- a/src/it/run-with-two-instances-it/pom.xml
+++ b/src/it/run-with-two-instances-it/pom.xml
@@ -24,7 +24,7 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <vertx.version>3.4.2</vertx.version>
+        <vertx.version>4.0.3</vertx.version>
         <vertx.verticle>demo.SimpleVerticle</vertx.verticle>
     </properties>
     <build>

--- a/src/it/run-with-two-instances-it/src/main/java/demo/SimpleVerticle.java
+++ b/src/it/run-with-two-instances-it/src/main/java/demo/SimpleVerticle.java
@@ -17,7 +17,7 @@
 package demo;
 
 import io.vertx.core.AbstractVerticle;
-import io.vertx.core.Future;
+import io.vertx.core.Promise;
 
 public class SimpleVerticle extends AbstractVerticle {
     @Override

--- a/src/it/run-worker-instances-it/pom.xml
+++ b/src/it/run-worker-instances-it/pom.xml
@@ -24,7 +24,7 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <vertx.version>3.4.2</vertx.version>
+        <vertx.version>4.0.3</vertx.version>
         <vertx.verticle>org.vertx.demo.SimpleVerticle</vertx.verticle>
     </properties>
     <build>

--- a/src/it/run-worker-instances-it/src/main/java/org/vertx/demo/SimpleVerticle.java
+++ b/src/it/run-worker-instances-it/src/main/java/org/vertx/demo/SimpleVerticle.java
@@ -17,14 +17,14 @@
 package org.vertx.demo;
 
 import io.vertx.core.AbstractVerticle;
-import io.vertx.core.Future;
+import io.vertx.core.Promise;
 
 /**
  * @author kameshs
  */
 public class SimpleVerticle extends AbstractVerticle {
     @Override
-    public void start(Future<Void> startFuture) throws Exception {
+    public void start(Promise<Void> startFuture) throws Exception {
         int instances = vertx.getOrCreateContext().getInstanceCount();
         System.out.println("Instances="+instances);
         startFuture.complete();

--- a/src/it/run-worker-it/pom.xml
+++ b/src/it/run-worker-it/pom.xml
@@ -24,7 +24,7 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <vertx.version>3.4.2</vertx.version>
+        <vertx.version>4.0.3</vertx.version>
         <vertx.verticle>org.vertx.demo.SimpleVerticle</vertx.verticle>
     </properties>
     <build>

--- a/src/it/run-worker-it/src/main/java/org/vertx/demo/SimpleVerticle.java
+++ b/src/it/run-worker-it/src/main/java/org/vertx/demo/SimpleVerticle.java
@@ -18,14 +18,14 @@
 package org.vertx.demo;
 
 import io.vertx.core.AbstractVerticle;
-import io.vertx.core.Future;
+import io.vertx.core.Promise;
 
 /**
  * @author kameshs
  */
 public class SimpleVerticle extends AbstractVerticle {
     @Override
-    public void start(Future<Void> startFuture) throws Exception {
+    public void start(Promise<Void> startFuture) throws Exception {
         startFuture.complete();
 
         vertx.close();

--- a/src/it/run-yaml-config-it/pom.xml
+++ b/src/it/run-yaml-config-it/pom.xml
@@ -25,7 +25,7 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <vertx.version>3.4.2</vertx.version>
+        <vertx.version>4.0.3</vertx.version>
         <vertx.verticle>org.vertx.demo.SimpleVerticle</vertx.verticle>
     </properties>
     <build>

--- a/src/it/run-yaml-options-it/pom.xml
+++ b/src/it/run-yaml-options-it/pom.xml
@@ -25,7 +25,7 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <vertx.version>3.8.0</vertx.version>
+        <vertx.version>4.0.3</vertx.version>
         <vertx.verticle>org.vertx.demo.SimpleVerticle</vertx.verticle>
     </properties>
     <build>

--- a/src/it/setup-with-diff-vertx-version-it/invoker.properties
+++ b/src/it/setup-with-diff-vertx-version-it/invoker.properties
@@ -13,4 +13,4 @@
 #    implied.  See the License for the specific language governing
 #    permissions and limitations under the License.
 #
-invoker.goals=${project.groupId}:${project.artifactId}:${project.version}:setup -DvertxVersion=3.4.0
+invoker.goals=${project.groupId}:${project.artifactId}:${project.version}:setup -DvertxVersion=4.0.3

--- a/src/it/signed-jar-it/pom.xml
+++ b/src/it/signed-jar-it/pom.xml
@@ -25,7 +25,7 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <vertx.version>3.4.2</vertx.version>
+        <vertx.version>4.0.3</vertx.version>
         <vertx.verticle>org.vertx.demo.MainVerticle</vertx.verticle>
     </properties>
     <build>

--- a/src/it/webjar-it/pom.xml
+++ b/src/it/webjar-it/pom.xml
@@ -25,7 +25,7 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <vertx.version>3.4.2</vertx.version>
+        <vertx.version>3.9.5</vertx.version>
         <vertx.verticle>org.vertx.demo.MainVerticle</vertx.verticle>
     </properties>
     <build>
@@ -70,7 +70,7 @@
         <dependency>
             <groupId>io.vertx</groupId>
             <artifactId>vertx-web</artifactId>
-            <version>3.3.3</version>
+            <version>3.9.5</version>
             <classifier>client</classifier>
             <type>js</type>
         </dependency>

--- a/src/it/webjar-no-strip-it/pom.xml
+++ b/src/it/webjar-no-strip-it/pom.xml
@@ -25,7 +25,7 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <vertx.version>3.4.2</vertx.version>
+        <vertx.version>3.9.5</vertx.version>
         <vertx.verticle>org.vertx.demo.MainVerticle</vertx.verticle>
     </properties>
     <build>
@@ -68,7 +68,7 @@
         <dependency>
             <groupId>io.vertx</groupId>
             <artifactId>vertx-web</artifactId>
-            <version>3.4.1</version>
+            <version>3.9.5</version>
             <classifier>client</classifier>
             <type>js</type>
         </dependency>

--- a/src/it/webjar-no-strip-it/verify.groovy
+++ b/src/it/webjar-no-strip-it/verify.groovy
@@ -27,5 +27,5 @@ Verify.verifyVertxJar(primaryArtifactFile)
 
 JarFile jar = new JarFile(primaryArtifactFile)
 assert jar.getEntry("assets") != null
-assert jar.getEntry("assets/vertx-web-3.4.1-client.js") != null
+assert jar.getEntry("assets/vertx-web-3.9.5-client.js") != null
 assert jar.getEntry("assets/jquery/3.1.1/jquery.js") != null

--- a/src/main/asciidoc/inc/_vertx-examples.adoc
+++ b/src/main/asciidoc/inc/_vertx-examples.adoc
@@ -51,7 +51,7 @@ with the following dependencies:
 <dependency>
     <groupId>io.vertx</groupId>
     <artifactId>vertx-web</artifactId>
-    <version>3.4.1</version>
+    <version>3.9.5</version>
     <classifier>client</classifier>
     <type>js</type>
 </dependency>
@@ -97,7 +97,7 @@ By default the plugin stripped the version. However this behavior can be disable
 </plugin>
 ----
 
-In this case, the `vertx-web-client.js` output file is: `vertx-web-3.4.1-client.js`, while for jquery, resources are
+In this case, the `vertx-web-client.js` output file is: `vertx-web-3.9.5-client.js`, while for jquery, resources are
 unpacked in `${project.baseDir}/target/classes/webroot/jquery/3.1.1`. You can always look into the
 `target/classes/webroot` directory to check the output files.
 

--- a/src/main/asciidoc/inc/_vertx-setup.adoc
+++ b/src/main/asciidoc/inc/_vertx-setup.adoc
@@ -17,11 +17,11 @@ if you wish to override the vertx version, then you can run the same command as 
 e.g.
 [source,subs=attributes+]
 ----
-mvn io.reactiverse:vertx-maven-plugin:{version}:setup -DvertxVersion=3.4.0
+mvn io.reactiverse:vertx-maven-plugin:{version}:setup -DvertxVersion=4.0.3
 ----
 
-This will configure the vert.x and its dependencies to `3.4.0` i.e. Maven project property `vertx.version`
-set to `3.4.0`
+This will configure the vert.x and its dependencies to `4.0.3` i.e. Maven project property `vertx.version`
+set to `4.0.3`
 
 You can also generate a project if you don't have a `pom.xml` file:
 
@@ -45,5 +45,5 @@ addition, you can configure dependencies using the following syntax: `groupId:ar
 ----
 io.vertx:vertxcodetrans => Inherit version from BOM
 commons-io:commons-io:2.5 => Regular dependency
-io.vertx:vertx-template-engines:3.4.1:shaded => Dependency with classifier
+io.vertx:vertx-template-engines:4.0.3:shaded => Dependency with classifier
 ----

--- a/src/test/java/io/reactiverse/vertx/maven/plugin/ExtraManifestInfoTest.java
+++ b/src/test/java/io/reactiverse/vertx/maven/plugin/ExtraManifestInfoTest.java
@@ -91,7 +91,7 @@ public class ExtraManifestInfoTest extends PlexusTestCase {
         assertThat(attributes.getValue("Manifest-Version")).isEqualTo("1.0");
         assertThat(attributes.getValue(PROJECT_NAME.header())).isEqualTo("vertx-demo");
         assertThat(attributes.getValue(BUILD_TIMESTAMP.header())).isNotNull().isNotEmpty();
-        assertThat(attributes.getValue(PROJECT_DEPS.header())).isEqualTo("io.vertx:vertx-core:3.4.1");
+        assertThat(attributes.getValue(PROJECT_DEPS.header())).isEqualTo("io.vertx:vertx-core:4.0.3");
         assertThat(attributes.getValue(PROJECT_GROUP_ID.header())).isEqualTo("org.vertx.demo");
         assertThat(attributes.getValue(PROJECT_VERSION.header())).isEqualTo("1.0.0-SNAPSHOT");
 
@@ -128,7 +128,7 @@ public class ExtraManifestInfoTest extends PlexusTestCase {
         assertThat(attributes.getValue("Manifest-Version")).isEqualTo("1.0");
         assertThat(attributes.getValue(PROJECT_NAME.header())).isEqualTo("vertx-demo");
         assertThat(attributes.getValue(BUILD_TIMESTAMP.header())).isNotNull().isNotEmpty();
-        assertThat(attributes.getValue(PROJECT_DEPS.header())).isEqualTo("com.example:example:3.4.1:vertx");
+        assertThat(attributes.getValue(PROJECT_DEPS.header())).isEqualTo("com.example:example:4.0.3:vertx");
         assertThat(attributes.getValue(PROJECT_GROUP_ID.header())).isEqualTo("org.vertx.demo");
         assertThat(attributes.getValue(PROJECT_VERSION.header())).isEqualTo("1.0.0-SNAPSHOT");
     }

--- a/src/test/java/io/reactiverse/vertx/maven/plugin/SetupMojoTest.java
+++ b/src/test/java/io/reactiverse/vertx/maven/plugin/SetupMojoTest.java
@@ -173,7 +173,7 @@ public class SetupMojoTest {
     @Test
     public void testAddVertxMavenPluginWithVertxVersion() throws Exception {
 
-        System.setProperty("vertxVersion", "3.4.0");
+        System.setProperty("vertxVersion", "4.0.3");
 
         InputStream pomFile = getClass().getResourceAsStream("/unit/setup/vmp-setup-pom.xml");
         assertNotNull(pomFile);

--- a/src/test/java/io/reactiverse/vertx/maven/plugin/Verify.java
+++ b/src/test/java/io/reactiverse/vertx/maven/plugin/Verify.java
@@ -147,7 +147,7 @@ public class Verify {
         Properties projectProps = project.getProperties();
         assertNotNull(projectProps);
         assertFalse(projectProps.isEmpty());
-        assertEquals(projectProps.getProperty("vertx.version"), "3.4.0");
+        assertEquals(projectProps.getProperty("vertx.version"), "4.0.3");
     }
 
     public static void verifySetupWithBom(File pomFile) throws Exception {
@@ -230,31 +230,12 @@ public class Verify {
             String expected = "foo.bar.baz.MyImpl\ncom.fasterxml.jackson.core.JsonFactory";
 
             ZipEntry spiEntry1 = jarFile.getEntry("META-INF/services/com.fasterxml.jackson.core.JsonFactory");
-            ZipEntry spiEntry2 = jarFile.getEntry("META-INF/services/io.vertx.core.spi.FutureFactory");
 
             assertThat(spiEntry1).isNotNull();
-            assertThat(spiEntry2).isNotNull();
 
             InputStream in = jarFile.getInputStream(spiEntry1);
             String actual = read(in);
             assertThat(actual).isEqualTo(expected);
-
-            in = jarFile.getInputStream(spiEntry2);
-            actual = read(in);
-            assertThat(actual).isEqualTo("io.vertx.core.impl.FutureFactoryImpl");
-
-            // This part is going to be used once Vert.x 3.4.0 is released //
-            // TODO Uncomment me once Vert.x 3.4.0 is released
-
-//            ZipEntry spiEntry3 = jarFile.getEntry("META-INF/services/org.codehaus.groovy.runtime.ExtensionModule");
-//            assertThat(spiEntry3).isNotNull();
-//            in = jarFile.getInputStream(spiEntry3);
-//            actual = read(in);
-//            assertThat(actual).contains("moduleName=vertx-demo-pkg")
-//                .contains("moduleVersion=0.0.1")
-//                .contains("io.vertx.groovy.ext.jdbc.GroovyStaticExtension")
-//                .contains("io.vertx.groovy.ext.jdbc.GroovyExtension");
-
         }
 
         protected void verifyOrderedServicesContent(String orderedContent) throws Exception {

--- a/src/test/java/io/reactiverse/vertx/maven/plugin/it/ExtraManifestInfoIT.java
+++ b/src/test/java/io/reactiverse/vertx/maven/plugin/it/ExtraManifestInfoIT.java
@@ -152,8 +152,8 @@ public class ExtraManifestInfoIT extends VertxMojoTestBase {
             assertThat(matcher.matches()).isTrue();
 
             assertThat(projectDeps)
-                .isEqualToIgnoringWhitespace("io.vertx:vertx-core:3.4.2 io.vertx:vertx-web:3.4.2 io" +
-                    ".vertx:vertx-jdbc-client:3.4.2");
+                .isEqualToIgnoringWhitespace("io.vertx:vertx-core:4.0.3 io.vertx:vertx-web:4.0.3 io" +
+                    ".vertx:vertx-jdbc-client:4.0.3");
         } else if ("svn".equalsIgnoreCase(scm)) {
             String scmType = manifest.getMainAttributes().getValue(
                 ExtraManifestKeys.SCM_TYPE.header());
@@ -164,7 +164,7 @@ public class ExtraManifestInfoIT extends VertxMojoTestBase {
             assertThat(revision).isNotNull();
             assertThat(revision).isEqualTo("1381106");
             assertThat(projectDeps)
-                .isEqualToIgnoringWhitespace("io.vertx:vertx-core:3.4.2 io.vertx:vertx-web:3.4.2");
+                .isEqualToIgnoringWhitespace("io.vertx:vertx-core:4.0.3 io.vertx:vertx-web:4.0.3");
         }
 
     }

--- a/src/test/java/io/reactiverse/vertx/maven/plugin/it/PackagingIT.java
+++ b/src/test/java/io/reactiverse/vertx/maven/plugin/it/PackagingIT.java
@@ -107,8 +107,8 @@ public class PackagingIT extends VertxMojoTestBase {
         assertThat(entry.isDirectory()).isFalse();
 
         // Jackson (transitive of vert.x core)
-        // /com/fasterxml/jackson/annotation/JacksonAnnotation.class
-        entry = jar.getJarEntry("com/fasterxml/jackson/annotation/JacksonAnnotation.class");
+        // /com/fasterxml/jackson/core/JsonParser.class
+        entry = jar.getJarEntry("com/fasterxml/jackson/core/JsonParser.class");
         assertThat(entry).isNotNull();
         assertThat(entry.isDirectory()).isFalse();
 

--- a/src/test/java/io/reactiverse/vertx/maven/plugin/it/SetupIT.java
+++ b/src/test/java/io/reactiverse/vertx/maven/plugin/it/SetupIT.java
@@ -98,14 +98,14 @@ public class SetupIT extends VertxMojoTestBase {
         initVerifier(testDir);
         setup(verifier, "-DprojectGroupId=org.acme", "-DprojectArtifactId=acme",
             "-Dverticle=org.acme.MyVerticle.java", "-Ddependencies=io.vertx:codetrans,commons-io:commons-io:2.5,io" +
-                ".vertx:vertx-template-engines:3.4.1:shaded");
+                ".vertx:vertx-template-engines:4.0.3:shaded");
         assertThat(new File(testDir, "pom.xml")).isFile();
         assertThat(new File(testDir, "src/main/java")).isDirectory();
         assertThat(new File(testDir, "src/main/java/org/acme/MyVerticle.java")).isFile();
         assertThat(FileUtils.readFileToString(new File(testDir, "pom.xml"), "UTF-8"))
             .contains("<artifactId>codetrans</artifactId>")
             .contains("<artifactId>commons-io</artifactId>", "<version>2.5</version>", "<groupId>commons-io</groupId>")
-            .contains("<artifactId>vertx-template-engines</artifactId>", "<version>3.4.1</version>",
+            .contains("<artifactId>vertx-template-engines</artifactId>", "<version>4.0.3</version>",
                 "<classifier>shaded</classifier>");;
     }
 

--- a/src/test/resources/projects/debug-it/pom.xml
+++ b/src/test/resources/projects/debug-it/pom.xml
@@ -25,7 +25,7 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <vertx.version>3.4.2</vertx.version>
+        <vertx.version>4.0.3</vertx.version>
     </properties>
     <build>
         <plugins>

--- a/src/test/resources/projects/debug-it/src/main/java/demo/SimpleVerticle.java
+++ b/src/test/resources/projects/debug-it/src/main/java/demo/SimpleVerticle.java
@@ -18,7 +18,7 @@
 package demo;
 
 import io.vertx.core.AbstractVerticle;
-import io.vertx.core.Future;
+import io.vertx.core.Promise;
 
 public class SimpleVerticle extends AbstractVerticle {
     @Override

--- a/src/test/resources/projects/debug-with-jvmArgs-it/pom.xml
+++ b/src/test/resources/projects/debug-with-jvmArgs-it/pom.xml
@@ -25,7 +25,7 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <vertx.version>3.4.2</vertx.version>
+        <vertx.version>4.0.3</vertx.version>
     </properties>
     <build>
         <plugins>

--- a/src/test/resources/projects/debug-with-jvmArgs-it/src/main/java/demo/SimpleVerticle.java
+++ b/src/test/resources/projects/debug-with-jvmArgs-it/src/main/java/demo/SimpleVerticle.java
@@ -18,7 +18,7 @@
 package demo;
 
 import io.vertx.core.AbstractVerticle;
-import io.vertx.core.Future;
+import io.vertx.core.Promise;
 
 public class SimpleVerticle extends AbstractVerticle {
     @Override

--- a/src/test/resources/projects/debug-with-main-class-it/pom.xml
+++ b/src/test/resources/projects/debug-with-main-class-it/pom.xml
@@ -25,7 +25,7 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <vertx.version>3.4.2</vertx.version>
+        <vertx.version>4.0.3</vertx.version>
     </properties>
     <build>
         <plugins>

--- a/src/test/resources/projects/debug-with-main-class-it/src/main/java/demo/Main.java
+++ b/src/test/resources/projects/debug-with-main-class-it/src/main/java/demo/Main.java
@@ -18,7 +18,7 @@
 package demo;
 
 import io.vertx.core.DeploymentOptions;
-import io.vertx.core.Future;
+import io.vertx.core.Promise;
 import io.vertx.core.Vertx;
 import io.vertx.core.json.JsonObject;
 

--- a/src/test/resources/projects/debug-with-main-class-it/src/main/java/demo/SimpleVerticle.java
+++ b/src/test/resources/projects/debug-with-main-class-it/src/main/java/demo/SimpleVerticle.java
@@ -18,7 +18,7 @@
 package demo;
 
 import io.vertx.core.AbstractVerticle;
-import io.vertx.core.Future;
+import io.vertx.core.Promise;
 
 public class SimpleVerticle extends AbstractVerticle {
     @Override

--- a/src/test/resources/projects/manifest-git-it/pom.xml
+++ b/src/test/resources/projects/manifest-git-it/pom.xml
@@ -31,7 +31,7 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <vertx.version>3.4.2</vertx.version>
+        <vertx.version>4.0.3</vertx.version>
     </properties>
     <build>
         <plugins>

--- a/src/test/resources/projects/manifest-git-it/src/main/java/demo/SimpleVerticle.java
+++ b/src/test/resources/projects/manifest-git-it/src/main/java/demo/SimpleVerticle.java
@@ -18,7 +18,7 @@
 package demo;
 
 import io.vertx.core.AbstractVerticle;
-import io.vertx.core.Future;
+import io.vertx.core.Promise;
 
 public class SimpleVerticle extends AbstractVerticle {
     @Override

--- a/src/test/resources/projects/manifest-svn-it/pom.xml
+++ b/src/test/resources/projects/manifest-svn-it/pom.xml
@@ -29,7 +29,7 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <vertx.version>3.4.2</vertx.version>
+        <vertx.version>4.0.3</vertx.version>
     </properties>
     <build>
         <plugins>

--- a/src/test/resources/projects/manifest-svn-it/src/main/java/demo/SimpleVerticle.java
+++ b/src/test/resources/projects/manifest-svn-it/src/main/java/demo/SimpleVerticle.java
@@ -18,7 +18,7 @@
 package demo;
 
 import io.vertx.core.AbstractVerticle;
-import io.vertx.core.Future;
+import io.vertx.core.Promise;
 
 public class SimpleVerticle extends AbstractVerticle {
     @Override

--- a/src/test/resources/projects/packaging-alternative-output-it/pom.xml
+++ b/src/test/resources/projects/packaging-alternative-output-it/pom.xml
@@ -25,7 +25,7 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <vertx.version>3.4.2</vertx.version>
+        <vertx.version>4.0.3</vertx.version>
     </properties>
     <build>
         <plugins>

--- a/src/test/resources/projects/packaging-alternative-output-it/src/main/java/demo/SimpleVerticle.java
+++ b/src/test/resources/projects/packaging-alternative-output-it/src/main/java/demo/SimpleVerticle.java
@@ -18,7 +18,7 @@
 package demo;
 
 import io.vertx.core.AbstractVerticle;
-import io.vertx.core.Future;
+import io.vertx.core.Promise;
 
 /**
  * @author kameshs

--- a/src/test/resources/projects/packaging-duplicate-it/pom.xml
+++ b/src/test/resources/projects/packaging-duplicate-it/pom.xml
@@ -25,7 +25,7 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <vertx.version>3.4.2</vertx.version>
+        <vertx.version>4.0.3</vertx.version>
     </properties>
     <build>
         <plugins>

--- a/src/test/resources/projects/packaging-duplicate-it/src/main/java/demo/SimpleVerticle.java
+++ b/src/test/resources/projects/packaging-duplicate-it/src/main/java/demo/SimpleVerticle.java
@@ -18,7 +18,7 @@
 package demo;
 
 import io.vertx.core.AbstractVerticle;
-import io.vertx.core.Future;
+import io.vertx.core.Promise;
 
 /**
  * @author kameshs

--- a/src/test/resources/projects/packaging-meta-inf-it/pom.xml
+++ b/src/test/resources/projects/packaging-meta-inf-it/pom.xml
@@ -25,7 +25,7 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <vertx.version>3.4.2</vertx.version>
+        <vertx.version>4.0.3</vertx.version>
     </properties>
     <build>
         <plugins>

--- a/src/test/resources/projects/packaging-meta-inf-it/src/main/java/demo/SimpleVerticle.java
+++ b/src/test/resources/projects/packaging-meta-inf-it/src/main/java/demo/SimpleVerticle.java
@@ -18,7 +18,7 @@
 package demo;
 
 import io.vertx.core.AbstractVerticle;
-import io.vertx.core.Future;
+import io.vertx.core.Promise;
 
 /**
  * @author kameshs

--- a/src/test/resources/projects/redeploy-it/pom.xml
+++ b/src/test/resources/projects/redeploy-it/pom.xml
@@ -25,7 +25,7 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <vertx.version>3.4.2</vertx.version>
+        <vertx.version>4.0.3</vertx.version>
     </properties>
     <build>
         <plugins>

--- a/src/test/resources/projects/redeploy-it/src/main/java/demo/SimpleVerticle.java
+++ b/src/test/resources/projects/redeploy-it/src/main/java/demo/SimpleVerticle.java
@@ -18,7 +18,7 @@
 package demo;
 
 import io.vertx.core.AbstractVerticle;
-import io.vertx.core.Future;
+import io.vertx.core.Promise;
 
 /**
  * @author kameshs

--- a/src/test/resources/projects/redeploy-on-resource-change-it/pom.xml
+++ b/src/test/resources/projects/redeploy-on-resource-change-it/pom.xml
@@ -25,7 +25,7 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <vertx.version>3.4.2</vertx.version>
+        <vertx.version>4.0.3</vertx.version>
     </properties>
     <build>
         <plugins>

--- a/src/test/resources/projects/redeploy-on-resource-change-it/src/main/java/demo/SimpleVerticle.java
+++ b/src/test/resources/projects/redeploy-on-resource-change-it/src/main/java/demo/SimpleVerticle.java
@@ -18,7 +18,7 @@
 package demo;
 
 import io.vertx.core.AbstractVerticle;
-import io.vertx.core.Future;
+import io.vertx.core.Promise;
 
 /**
  * @author kameshs

--- a/src/test/resources/projects/redeploy-scan-period-it/pom.xml
+++ b/src/test/resources/projects/redeploy-scan-period-it/pom.xml
@@ -25,7 +25,7 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <vertx.version>3.4.2</vertx.version>
+        <vertx.version>4.0.3</vertx.version>
     </properties>
     <build>
         <plugins>

--- a/src/test/resources/projects/redeploy-with-custom-launcher-it/pom.xml
+++ b/src/test/resources/projects/redeploy-with-custom-launcher-it/pom.xml
@@ -25,7 +25,7 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <vertx.version>3.4.2</vertx.version>
+        <vertx.version>4.0.3</vertx.version>
     </properties>
     <build>
         <plugins>

--- a/src/test/resources/projects/redeploy-with-custom-launcher-it/src/main/java/demo/SimpleVerticle.java
+++ b/src/test/resources/projects/redeploy-with-custom-launcher-it/src/main/java/demo/SimpleVerticle.java
@@ -18,7 +18,7 @@
 package demo;
 
 import io.vertx.core.AbstractVerticle;
-import io.vertx.core.Future;
+import io.vertx.core.Promise;
 
 public class SimpleVerticle extends AbstractVerticle {
     @Override

--- a/src/test/resources/projects/redeploy-with-extended-launcher-it/pom.xml
+++ b/src/test/resources/projects/redeploy-with-extended-launcher-it/pom.xml
@@ -25,7 +25,7 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <vertx.version>3.4.2</vertx.version>
+        <vertx.version>4.0.3</vertx.version>
     </properties>
     <build>
         <plugins>

--- a/src/test/resources/projects/redeploy-with-extended-launcher-it/src/main/java/demo/SimpleVerticle.java
+++ b/src/test/resources/projects/redeploy-with-extended-launcher-it/src/main/java/demo/SimpleVerticle.java
@@ -18,7 +18,7 @@
 package demo;
 
 import io.vertx.core.AbstractVerticle;
-import io.vertx.core.Future;
+import io.vertx.core.Promise;
 
 public class SimpleVerticle extends AbstractVerticle {
     @Override

--- a/src/test/resources/projects/redeploy-with-jvmArgs-it/pom.xml
+++ b/src/test/resources/projects/redeploy-with-jvmArgs-it/pom.xml
@@ -25,7 +25,7 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <vertx.version>3.4.2</vertx.version>
+        <vertx.version>4.0.3</vertx.version>
     </properties>
     <build>
         <plugins>

--- a/src/test/resources/projects/redeploy-with-jvmArgs-it/src/main/java/demo/SimpleVerticle.java
+++ b/src/test/resources/projects/redeploy-with-jvmArgs-it/src/main/java/demo/SimpleVerticle.java
@@ -18,7 +18,7 @@
 package demo;
 
 import io.vertx.core.AbstractVerticle;
-import io.vertx.core.Future;
+import io.vertx.core.Promise;
 
 /**
  * @author kameshs

--- a/src/test/resources/projects/redeploy-with-some-plugin-it/pom.xml
+++ b/src/test/resources/projects/redeploy-with-some-plugin-it/pom.xml
@@ -25,7 +25,7 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <vertx.version>3.4.2</vertx.version>
+        <vertx.version>4.0.3</vertx.version>
     </properties>
     <build>
         <plugins>

--- a/src/test/resources/projects/redeploy-with-some-plugin-it/src/main/java/demo/SimpleVerticle.java
+++ b/src/test/resources/projects/redeploy-with-some-plugin-it/src/main/java/demo/SimpleVerticle.java
@@ -18,7 +18,7 @@
 package demo;
 
 import io.vertx.core.AbstractVerticle;
-import io.vertx.core.Future;
+import io.vertx.core.Promise;
 
 /**
  * @author kameshs

--- a/src/test/resources/projects/run-filtering-it/pom.xml
+++ b/src/test/resources/projects/run-filtering-it/pom.xml
@@ -25,7 +25,7 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <vertx.version>3.4.2</vertx.version>
+        <vertx.version>4.0.3</vertx.version>
 
         <!-- Message injected in the resource -->
         <message>aloha</message>

--- a/src/test/resources/projects/run-filtering-it/src/main/java/demo/SimpleVerticle.java
+++ b/src/test/resources/projects/run-filtering-it/src/main/java/demo/SimpleVerticle.java
@@ -18,7 +18,7 @@
 package demo;
 
 import io.vertx.core.AbstractVerticle;
-import io.vertx.core.Future;
+import io.vertx.core.Promise;
 
 /**
  * @author kameshs

--- a/src/test/resources/projects/start-exploded-it/pom.xml
+++ b/src/test/resources/projects/start-exploded-it/pom.xml
@@ -25,7 +25,7 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <vertx.version>3.4.2</vertx.version>
+        <vertx.version>4.0.3</vertx.version>
     </properties>
     <build>
         <plugins>

--- a/src/test/resources/projects/start-exploded-it/src/main/java/demo/SimpleVerticle.java
+++ b/src/test/resources/projects/start-exploded-it/src/main/java/demo/SimpleVerticle.java
@@ -18,7 +18,7 @@
 package demo;
 
 import io.vertx.core.AbstractVerticle;
-import io.vertx.core.Future;
+import io.vertx.core.Promise;
 
 /**
  * @author kameshs

--- a/src/test/resources/projects/start-it/pom.xml
+++ b/src/test/resources/projects/start-it/pom.xml
@@ -25,7 +25,7 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <vertx.version>3.4.2</vertx.version>
+        <vertx.version>4.0.3</vertx.version>
     </properties>
     <build>
         <plugins>

--- a/src/test/resources/projects/start-it/src/main/java/demo/SimpleVerticle.java
+++ b/src/test/resources/projects/start-it/src/main/java/demo/SimpleVerticle.java
@@ -18,7 +18,7 @@
 package demo;
 
 import io.vertx.core.AbstractVerticle;
-import io.vertx.core.Future;
+import io.vertx.core.Promise;
 
 /**
  * @author kameshs

--- a/src/test/resources/projects/start-java-opts-it/pom.xml
+++ b/src/test/resources/projects/start-java-opts-it/pom.xml
@@ -25,7 +25,7 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <vertx.version>3.4.2</vertx.version>
+        <vertx.version>4.0.3</vertx.version>
         <vertx.verticle>org.vertx.demo.SimpleVerticle</vertx.verticle>
     </properties>
     <build>

--- a/src/test/resources/projects/start-java-opts-it/src/main/java/org/vertx/demo/SimpleVerticle.java
+++ b/src/test/resources/projects/start-java-opts-it/src/main/java/org/vertx/demo/SimpleVerticle.java
@@ -18,7 +18,7 @@
 package org.vertx.demo;
 
 import io.vertx.core.AbstractVerticle;
-import io.vertx.core.Future;
+import io.vertx.core.Promise;
 
 /**
  * @author kameshs

--- a/src/test/resources/projects/start-with-conf-exploded-it/pom.xml
+++ b/src/test/resources/projects/start-with-conf-exploded-it/pom.xml
@@ -25,7 +25,7 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <vertx.version>3.4.2</vertx.version>
+        <vertx.version>4.0.3</vertx.version>
     </properties>
     <build>
         <plugins>

--- a/src/test/resources/projects/start-with-conf-exploded-it/src/main/java/demo/SimpleVerticle.java
+++ b/src/test/resources/projects/start-with-conf-exploded-it/src/main/java/demo/SimpleVerticle.java
@@ -18,7 +18,7 @@
 package demo;
 
 import io.vertx.core.AbstractVerticle;
-import io.vertx.core.Future;
+import io.vertx.core.Promise;
 
 /**
  * @author kameshs

--- a/src/test/resources/projects/start-with-conf-it/pom.xml
+++ b/src/test/resources/projects/start-with-conf-it/pom.xml
@@ -25,7 +25,7 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <vertx.version>3.4.2</vertx.version>
+        <vertx.version>4.0.3</vertx.version>
     </properties>
     <build>
         <plugins>

--- a/src/test/resources/projects/start-with-conf-it/src/main/java/demo/SimpleVerticle.java
+++ b/src/test/resources/projects/start-with-conf-it/src/main/java/demo/SimpleVerticle.java
@@ -18,7 +18,7 @@
 package demo;
 
 import io.vertx.core.AbstractVerticle;
-import io.vertx.core.Future;
+import io.vertx.core.Promise;
 
 /**
  * @author kameshs

--- a/src/test/resources/projects/start-with-custom-launcher-exploded-it/pom.xml
+++ b/src/test/resources/projects/start-with-custom-launcher-exploded-it/pom.xml
@@ -25,7 +25,7 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <vertx.version>3.4.2</vertx.version>
+        <vertx.version>4.0.3</vertx.version>
     </properties>
     <build>
         <plugins>

--- a/src/test/resources/projects/start-with-custom-launcher-exploded-it/src/main/java/demo/Main.java
+++ b/src/test/resources/projects/start-with-custom-launcher-exploded-it/src/main/java/demo/Main.java
@@ -18,7 +18,7 @@
 package demo;
 
 import io.vertx.core.DeploymentOptions;
-import io.vertx.core.Future;
+import io.vertx.core.Promise;
 import io.vertx.core.Launcher;
 import io.vertx.core.Vertx;
 import io.vertx.core.json.JsonObject;

--- a/src/test/resources/projects/start-with-custom-launcher-exploded-it/src/main/java/demo/SimpleVerticle.java
+++ b/src/test/resources/projects/start-with-custom-launcher-exploded-it/src/main/java/demo/SimpleVerticle.java
@@ -18,7 +18,7 @@
 package demo;
 
 import io.vertx.core.AbstractVerticle;
-import io.vertx.core.Future;
+import io.vertx.core.Promise;
 
 /**
  * @author kameshs

--- a/src/test/resources/projects/start-with-custom-launcher-it/pom.xml
+++ b/src/test/resources/projects/start-with-custom-launcher-it/pom.xml
@@ -25,7 +25,7 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <vertx.version>3.4.2</vertx.version>
+        <vertx.version>4.0.3</vertx.version>
     </properties>
     <build>
         <plugins>

--- a/src/test/resources/projects/start-with-custom-launcher-it/src/main/java/demo/Main.java
+++ b/src/test/resources/projects/start-with-custom-launcher-it/src/main/java/demo/Main.java
@@ -18,7 +18,7 @@
 package demo;
 
 import io.vertx.core.DeploymentOptions;
-import io.vertx.core.Future;
+import io.vertx.core.Promise;
 import io.vertx.core.Launcher;
 import io.vertx.core.Vertx;
 import io.vertx.core.json.JsonObject;

--- a/src/test/resources/projects/start-with-custom-launcher-it/src/main/java/demo/SimpleVerticle.java
+++ b/src/test/resources/projects/start-with-custom-launcher-it/src/main/java/demo/SimpleVerticle.java
@@ -18,7 +18,7 @@
 package demo;
 
 import io.vertx.core.AbstractVerticle;
-import io.vertx.core.Future;
+import io.vertx.core.Promise;
 
 /**
  * @author kameshs

--- a/src/test/resources/projects/start-with-main-class-exploded-it/pom.xml
+++ b/src/test/resources/projects/start-with-main-class-exploded-it/pom.xml
@@ -25,7 +25,7 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <vertx.version>3.4.2</vertx.version>
+        <vertx.version>4.0.3</vertx.version>
     </properties>
     <build>
         <plugins>

--- a/src/test/resources/projects/start-with-main-class-exploded-it/src/main/java/demo/Main.java
+++ b/src/test/resources/projects/start-with-main-class-exploded-it/src/main/java/demo/Main.java
@@ -18,7 +18,7 @@
 package demo;
 
 import io.vertx.core.DeploymentOptions;
-import io.vertx.core.Future;
+import io.vertx.core.Promise;
 import io.vertx.core.Vertx;
 import io.vertx.core.json.JsonObject;
 

--- a/src/test/resources/projects/start-with-main-class-exploded-it/src/main/java/demo/SimpleVerticle.java
+++ b/src/test/resources/projects/start-with-main-class-exploded-it/src/main/java/demo/SimpleVerticle.java
@@ -18,7 +18,7 @@
 package demo;
 
 import io.vertx.core.AbstractVerticle;
-import io.vertx.core.Future;
+import io.vertx.core.Promise;
 
 /**
  * @author kameshs

--- a/src/test/resources/projects/start-with-main-class-it/pom.xml
+++ b/src/test/resources/projects/start-with-main-class-it/pom.xml
@@ -25,7 +25,7 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <vertx.version>3.4.2</vertx.version>
+        <vertx.version>4.0.3</vertx.version>
     </properties>
     <build>
         <plugins>

--- a/src/test/resources/projects/start-with-main-class-it/src/main/java/demo/Main.java
+++ b/src/test/resources/projects/start-with-main-class-it/src/main/java/demo/Main.java
@@ -18,7 +18,7 @@
 package demo;
 
 import io.vertx.core.DeploymentOptions;
-import io.vertx.core.Future;
+import io.vertx.core.Promise;
 import io.vertx.core.Vertx;
 import io.vertx.core.json.JsonObject;
 

--- a/src/test/resources/projects/start-with-main-class-it/src/main/java/demo/SimpleVerticle.java
+++ b/src/test/resources/projects/start-with-main-class-it/src/main/java/demo/SimpleVerticle.java
@@ -18,7 +18,7 @@
 package demo;
 
 import io.vertx.core.AbstractVerticle;
-import io.vertx.core.Future;
+import io.vertx.core.Promise;
 
 /**
  * @author kameshs

--- a/src/test/resources/unit/jar-packaging/pom-extramf-classifier-jar.xml
+++ b/src/test/resources/unit/jar-packaging/pom-extramf-classifier-jar.xml
@@ -29,12 +29,12 @@
             <groupId>com.example</groupId>
             <artifactId>example</artifactId>
             <classifier>vertx</classifier>
-            <version>3.4.1</version>
+            <version>4.0.3</version>
         </dependency>
         <dependency>
             <groupId>io.vertx</groupId>
             <artifactId>vertx-unit</artifactId>
-            <version>3.4.1</version>
+            <version>4.0.3</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/src/test/resources/unit/jar-packaging/pom-extramf-jar.xml
+++ b/src/test/resources/unit/jar-packaging/pom-extramf-jar.xml
@@ -28,12 +28,12 @@
         <dependency>
             <groupId>io.vertx</groupId>
             <artifactId>vertx-core</artifactId>
-            <version>3.4.1</version>
+            <version>4.0.3</version>
         </dependency>
         <dependency>
             <groupId>io.vertx</groupId>
             <artifactId>vertx-unit</artifactId>
-            <version>3.4.1</version>
+            <version>4.0.3</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/src/test/resources/unit/jar-packaging/pom-extramf-scm-jar.xml
+++ b/src/test/resources/unit/jar-packaging/pom-extramf-scm-jar.xml
@@ -42,7 +42,7 @@
         <dependency>
             <groupId>io.vertx</groupId>
             <artifactId>vertx-unit</artifactId>
-            <version>3.4.1</version>
+            <version>4.0.3</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/src/test/resources/unit/jar-packaging/pom-jar.xml
+++ b/src/test/resources/unit/jar-packaging/pom-jar.xml
@@ -53,7 +53,7 @@
     </build>
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <vertx.version>3.3.2</vertx.version>
+        <vertx.version>4.0.3</vertx.version>
         <vertx.verticle>org.vertx.demo.MainVerticle</vertx.verticle>
     </properties>
     <dependencies>


### PR DESCRIPTION
Kept a couple of tests which work with Vert.x Web Client JS dependency on 3.9.5

Follows-up on #274