### PR TITLE
Intermittent failure in testRedeployOnJavaChangeWithCustomLauncher

### DIFF
--- a/src/test/resources/projects/redeploy-with-custom-launcher-it/src/main/java/demo/Main.java
+++ b/src/test/resources/projects/redeploy-with-custom-launcher-it/src/main/java/demo/Main.java
@@ -2,6 +2,9 @@ package demo;
 
 import io.vertx.core.DeploymentOptions;
 import io.vertx.core.Vertx;
+import io.vertx.core.impl.launcher.commands.BareCommand;
+import io.vertx.core.impl.logging.Logger;
+import io.vertx.core.impl.logging.LoggerFactory;
 import io.vertx.core.json.JsonObject;
 
 /**
@@ -9,9 +12,13 @@ import io.vertx.core.json.JsonObject;
  */
 public class Main {
 
+    private static final Logger log = LoggerFactory.getLogger(Main.class);
+
     public static void main(String[] args) {
         String prefix = "Bonjour";
         Vertx vertx = Vertx.vertx();
+        Runtime.getRuntime().addShutdownHook(new Thread(BareCommand.getTerminationRunnable(vertx, log, null)));
+
         vertx.deployVerticle(SimpleVerticle.class.getName(), new DeploymentOptions()
             .setConfig(new JsonObject().put("prefix", prefix)));
     }


### PR DESCRIPTION
Fixes #534

In this test, Main is a simple Java class that does not extend Launcher. When redeployment occurs, the process does not stop cleanly and the server socket may still be bound when the new process starts.

Adding a shutdown hook should guarantee that the process stops cleanly and the new process can bind the server stockets when it starts.