### PR TITLE
Vert.x test version upgrade

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -429,6 +429,9 @@
                         <excludes>
                             <exclude>**/IT*.java</exclude>
                         </excludes>
+                        <systemPropertyVariables>
+                            <vertx-core.version>${vertx-core.version}</vertx-core.version>
+                        </systemPropertyVariables>
                     </configuration>
                 </plugin>
             </plugins>
@@ -474,6 +477,7 @@
                                 <systemPropertyVariables>
                                     <!--suppress MavenModelInspection -->
                                     <maven.home>${maven.home}</maven.home>
+                                    <vertx-core.version>${vertx-core.version}</vertx-core.version>
                                 </systemPropertyVariables>
                             </configuration>
                         </plugin>
@@ -567,6 +571,7 @@
                                 <idprefix />
                                 <idseparator>-</idseparator>
                                 <toc>left</toc>
+                                <vertx-core-version>${vertx-core.version}</vertx-core-version>
                             </attributes>
                             <backend>html</backend>
                             <sourceHighlighter>highlightjs</sourceHighlighter>

--- a/pom.xml
+++ b/pom.xml
@@ -131,7 +131,7 @@
         <jline.version>3.26.1</jline.version>
 
         <!-- Test dependency versions -->
-        <vertx-core.version>4.3.1</vertx-core.version>
+        <vertx-core.version>4.5.8</vertx-core.version>
         <assertj-core.version>3.26.0</assertj-core.version>
         <junit.version>4.13.2</junit.version>
         <maven-verifier.version>1.7.2</maven-verifier.version>

--- a/src/it/help-it/pom.xml
+++ b/src/it/help-it/pom.xml
@@ -25,7 +25,7 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <vertx.version>4.3.1</vertx.version>
+        <vertx.version>@vertx-core.version@</vertx.version>
         <vertx.verticle>org.vertx.demo.MainVerticle</vertx.verticle>
     </properties>
     <build>

--- a/src/it/package-archive-all-it/pom.xml
+++ b/src/it/package-archive-all-it/pom.xml
@@ -25,7 +25,7 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <vertx.version>4.3.1</vertx.version>
+        <vertx.version>@vertx-core.version@</vertx.version>
         <vertx.verticle>org.vertx.demo.MainVerticle</vertx.verticle>
     </properties>
     <build>

--- a/src/it/package-archive-combination-it/package-spi-deps-order-it/pom.xml
+++ b/src/it/package-archive-combination-it/package-spi-deps-order-it/pom.xml
@@ -27,7 +27,7 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <vertx.version>4.3.1</vertx.version>
+        <vertx.version>@vertx-core.version@</vertx.version>
         <vertx.verticle>org.vertx.demo.MainVerticle</vertx.verticle>
     </properties>
     <build>

--- a/src/it/package-archive-combination-it/package-spi-deps-order2-it/pom.xml
+++ b/src/it/package-archive-combination-it/package-spi-deps-order2-it/pom.xml
@@ -27,7 +27,7 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <vertx.version>4.3.1</vertx.version>
+        <vertx.version>@vertx-core.version@</vertx.version>
         <vertx.verticle>org.vertx.demo.MainVerticle</vertx.verticle>
     </properties>
     <build>

--- a/src/it/package-archive-dependencies-it/pom.xml
+++ b/src/it/package-archive-dependencies-it/pom.xml
@@ -25,6 +25,7 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <log4j.version>2.22.1</log4j.version>
         <vertx.version>@vertx-core.version@</vertx.version>
         <vertx.verticle>org.vertx.demo.MainVerticle</vertx.verticle>
     </properties>
@@ -81,8 +82,11 @@
 
         <dependency>
             <groupId>org.apache.logging.log4j</groupId>
+            <artifactId>log4j-api</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.logging.log4j</groupId>
             <artifactId>log4j-core</artifactId>
-            <version>2.18.0</version>
         </dependency>
 
         <dependency>
@@ -94,6 +98,13 @@
     </dependencies>
     <dependencyManagement>
         <dependencies>
+            <dependency>
+                <groupId>org.apache.logging.log4j</groupId>
+                <artifactId>log4j-bom</artifactId>
+                <version>${log4j.version}</version>
+                <scope>import</scope>
+                <type>pom</type>
+            </dependency>
             <dependency>
                 <groupId>io.vertx</groupId>
                 <artifactId>vertx-stack-depchain</artifactId>

--- a/src/it/package-archive-dependencies-it/pom.xml
+++ b/src/it/package-archive-dependencies-it/pom.xml
@@ -25,7 +25,7 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <vertx.version>4.3.1</vertx.version>
+        <vertx.version>@vertx-core.version@</vertx.version>
         <vertx.verticle>org.vertx.demo.MainVerticle</vertx.verticle>
     </properties>
     <build>

--- a/src/it/package-archive-file-inclusion-it/pom.xml
+++ b/src/it/package-archive-file-inclusion-it/pom.xml
@@ -25,7 +25,7 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <vertx.version>4.3.1</vertx.version>
+        <vertx.version>@vertx-core.version@</vertx.version>
         <vertx.verticle>org.vertx.demo.MainVerticle</vertx.verticle>
     </properties>
     <build>

--- a/src/it/package-archive-fileset-it/pom.xml
+++ b/src/it/package-archive-fileset-it/pom.xml
@@ -25,7 +25,7 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <vertx.version>4.3.1</vertx.version>
+        <vertx.version>@vertx-core.version@</vertx.version>
         <vertx.verticle>org.vertx.demo.MainVerticle</vertx.verticle>
     </properties>
     <build>

--- a/src/it/package-archive-include-classes-it/pom.xml
+++ b/src/it/package-archive-include-classes-it/pom.xml
@@ -25,7 +25,7 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <vertx.version>4.3.1</vertx.version>
+        <vertx.version>@vertx-core.version@</vertx.version>
         <vertx.verticle>org.vertx.demo.MainVerticle</vertx.verticle>
     </properties>
     <build>

--- a/src/it/package-archive-it/pom.xml
+++ b/src/it/package-archive-it/pom.xml
@@ -25,7 +25,7 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <vertx.version>4.3.1</vertx.version>
+        <vertx.version>@vertx-core.version@</vertx.version>
         <vertx.verticle>org.vertx.demo.MainVerticle</vertx.verticle>
     </properties>
     <build>

--- a/src/it/package-archive-manifest-it/pom.xml
+++ b/src/it/package-archive-manifest-it/pom.xml
@@ -25,7 +25,7 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <vertx.version>4.3.1</vertx.version>
+        <vertx.version>@vertx-core.version@</vertx.version>
         <vertx.verticle>org.vertx.demo.MainVerticle</vertx.verticle>
     </properties>
     <build>

--- a/src/it/package-archive-no-jar-it/pom.xml
+++ b/src/it/package-archive-no-jar-it/pom.xml
@@ -25,7 +25,7 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <vertx.version>4.3.1</vertx.version>
+        <vertx.version>@vertx-core.version@</vertx.version>
         <vertx.verticle>org.vertx.demo.MainVerticle</vertx.verticle>
     </properties>
     <build>

--- a/src/it/package-it/pom.xml
+++ b/src/it/package-it/pom.xml
@@ -25,7 +25,7 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <vertx.version>4.3.1</vertx.version>
+        <vertx.version>@vertx-core.version@</vertx.version>
         <vertx.verticle>org.vertx.demo.MainVerticle</vertx.verticle>
     </properties>
     <build>

--- a/src/it/package-log4j2-plugin-it/pom.xml
+++ b/src/it/package-log4j2-plugin-it/pom.xml
@@ -25,7 +25,7 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <vertx.version>4.3.1</vertx.version>
+        <vertx.version>@vertx-core.version@</vertx.version>
         <vertx.launcher>org.vertx.demo.Main</vertx.launcher>
     </properties>
     <build>

--- a/src/it/package-log4j2-plugin-it/pom.xml
+++ b/src/it/package-log4j2-plugin-it/pom.xml
@@ -25,6 +25,7 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <log4j.version>2.22.1</log4j.version>
         <vertx.version>@vertx-core.version@</vertx.version>
         <vertx.launcher>org.vertx.demo.Main</vertx.launcher>
     </properties>
@@ -81,16 +82,21 @@
         <dependency>
             <groupId>org.apache.logging.log4j</groupId>
             <artifactId>log4j-api</artifactId>
-            <version>2.18.0</version>
         </dependency>
         <dependency>
             <groupId>org.apache.logging.log4j</groupId>
             <artifactId>log4j-core</artifactId>
-            <version>2.18.0</version>
         </dependency>
     </dependencies>
     <dependencyManagement>
         <dependencies>
+            <dependency>
+                <groupId>org.apache.logging.log4j</groupId>
+                <artifactId>log4j-bom</artifactId>
+                <version>${log4j.version}</version>
+                <scope>import</scope>
+                <type>pom</type>
+            </dependency>
             <dependency>
                 <groupId>io.vertx</groupId>
                 <artifactId>vertx-stack-depchain</artifactId>

--- a/src/it/package-no-jar-it/pom.xml
+++ b/src/it/package-no-jar-it/pom.xml
@@ -25,7 +25,7 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <vertx.version>4.3.1</vertx.version>
+        <vertx.version>@vertx-core.version@</vertx.version>
         <vertx.verticle>org.vertx.demo.MainVerticle</vertx.verticle>
     </properties>
     <build>

--- a/src/it/package-nofinal-name-it/pom.xml
+++ b/src/it/package-nofinal-name-it/pom.xml
@@ -26,7 +26,7 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <vertx.version>4.3.1</vertx.version>
+        <vertx.version>@vertx-core.version@</vertx.version>
         <vertx.verticle>org.vertx.demo.MainVerticle</vertx.verticle>
     </properties>
     <build>

--- a/src/it/package-spi-it/pom.xml
+++ b/src/it/package-spi-it/pom.xml
@@ -25,7 +25,7 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <vertx.version>4.3.1</vertx.version>
+        <vertx.version>@vertx-core.version@</vertx.version>
         <vertx.verticle>org.vertx.demo.MainVerticle</vertx.verticle>
     </properties>
     <build>

--- a/src/it/package-spi-order-combination-it/package-spi-deps-order-it/pom.xml
+++ b/src/it/package-spi-order-combination-it/package-spi-deps-order-it/pom.xml
@@ -27,7 +27,7 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <vertx.version>4.3.1</vertx.version>
+        <vertx.version>@vertx-core.version@</vertx.version>
         <vertx.verticle>org.vertx.demo.MainVerticle</vertx.verticle>
     </properties>
     <build>

--- a/src/it/package-spi-order-combination-it/package-spi-deps-order2-it/pom.xml
+++ b/src/it/package-spi-order-combination-it/package-spi-deps-order2-it/pom.xml
@@ -27,7 +27,7 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <vertx.version>4.3.1</vertx.version>
+        <vertx.version>@vertx-core.version@</vertx.version>
         <vertx.verticle>org.vertx.demo.MainVerticle</vertx.verticle>
     </properties>
     <build>

--- a/src/it/package-with-classifier-it/pom.xml
+++ b/src/it/package-with-classifier-it/pom.xml
@@ -25,7 +25,7 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <vertx.version>4.3.1</vertx.version>
+        <vertx.version>@vertx-core.version@</vertx.version>
         <vertx.verticle>org.vertx.demo.MainVerticle</vertx.verticle>
     </properties>
     <build>

--- a/src/it/package-withfinal-name-it/pom.xml
+++ b/src/it/package-withfinal-name-it/pom.xml
@@ -26,7 +26,7 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <vertx.version>4.3.1</vertx.version>
+        <vertx.version>@vertx-core.version@</vertx.version>
         <vertx.verticle>org.vertx.demo.MainVerticle</vertx.verticle>
     </properties>
     <build>

--- a/src/it/run-args-custom-launcher-it/pom.xml
+++ b/src/it/run-args-custom-launcher-it/pom.xml
@@ -24,7 +24,7 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <vertx.version>4.3.1</vertx.version>
+        <vertx.version>@vertx-core.version@</vertx.version>
     </properties>
     <build>
         <plugins>

--- a/src/it/run-args-extended-launcher-it/pom.xml
+++ b/src/it/run-args-extended-launcher-it/pom.xml
@@ -24,7 +24,7 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <vertx.version>4.3.1</vertx.version>
+        <vertx.version>@vertx-core.version@</vertx.version>
     </properties>
     <build>
         <plugins>

--- a/src/it/run-cluster-defaults-it/pom.xml
+++ b/src/it/run-cluster-defaults-it/pom.xml
@@ -24,7 +24,7 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <vertx.version>4.3.1</vertx.version>
+        <vertx.version>@vertx-core.version@</vertx.version>
         <vertx.verticle>org.vertx.demo.SimpleVerticle</vertx.verticle>
     </properties>
     <build>

--- a/src/it/run-config-it/pom.xml
+++ b/src/it/run-config-it/pom.xml
@@ -25,7 +25,7 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <vertx.version>4.3.1</vertx.version>
+        <vertx.version>@vertx-core.version@</vertx.version>
         <vertx.verticle>org.vertx.demo.SimpleVerticle</vertx.verticle>
     </properties>
     <build>

--- a/src/it/run-config-param-it/pom.xml
+++ b/src/it/run-config-param-it/pom.xml
@@ -25,7 +25,7 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <vertx.version>4.3.1</vertx.version>
+        <vertx.version>@vertx-core.version@</vertx.version>
         <vertx.verticle>org.vertx.demo.SimpleVerticle</vertx.verticle>
     </properties>
     <build>

--- a/src/it/run-ha-defaults-it/pom.xml
+++ b/src/it/run-ha-defaults-it/pom.xml
@@ -24,7 +24,7 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <vertx.version>4.3.1</vertx.version>
+        <vertx.version>@vertx-core.version@</vertx.version>
         <vertx.verticle>org.vertx.demo.SimpleVerticle</vertx.verticle>
     </properties>
     <build>

--- a/src/it/run-ha-group-it/pom.xml
+++ b/src/it/run-ha-group-it/pom.xml
@@ -24,7 +24,7 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <vertx.version>4.3.1</vertx.version>
+        <vertx.version>@vertx-core.version@</vertx.version>
         <vertx.verticle>demo.SimpleVerticle</vertx.verticle>
     </properties>
     <build>

--- a/src/it/run-ha-quorum-it/pom.xml
+++ b/src/it/run-ha-quorum-it/pom.xml
@@ -24,7 +24,7 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <vertx.version>4.3.1</vertx.version>
+        <vertx.version>@vertx-core.version@</vertx.version>
         <vertx.verticle>demo.SimpleVerticle</vertx.verticle>
     </properties>
     <build>

--- a/src/it/run-it/pom.xml
+++ b/src/it/run-it/pom.xml
@@ -25,7 +25,7 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <vertx.version>4.3.1</vertx.version>
+        <vertx.version>@vertx-core.version@</vertx.version>
         <vertx.verticle>org.vertx.demo.SimpleVerticle</vertx.verticle>
     </properties>
     <build>

--- a/src/it/run-options-it/pom.xml
+++ b/src/it/run-options-it/pom.xml
@@ -25,7 +25,7 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <vertx.version>4.3.1</vertx.version>
+        <vertx.version>@vertx-core.version@</vertx.version>
         <vertx.verticle>org.vertx.demo.SimpleVerticle</vertx.verticle>
     </properties>
     <build>

--- a/src/it/run-redeploy-it/pom.xml
+++ b/src/it/run-redeploy-it/pom.xml
@@ -25,7 +25,7 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <vertx.version>4.3.1</vertx.version>
+        <vertx.version>@vertx-core.version@</vertx.version>
         <vertx.verticle>org.vertx.demo.SimpleVerticle</vertx.verticle>
         <vertx.launcher>org.vertx.demo.MyLauncher</vertx.launcher>
     </properties>

--- a/src/it/run-with-jvmArgs-it/pom.xml
+++ b/src/it/run-with-jvmArgs-it/pom.xml
@@ -25,7 +25,7 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <vertx.version>4.3.1</vertx.version>
+        <vertx.version>@vertx-core.version@</vertx.version>
         <vertx.verticle>org.vertx.demo.SimpleVerticle</vertx.verticle>
     </properties>
     <build>

--- a/src/it/run-with-two-instances-it/pom.xml
+++ b/src/it/run-with-two-instances-it/pom.xml
@@ -24,7 +24,7 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <vertx.version>4.3.1</vertx.version>
+        <vertx.version>@vertx-core.version@</vertx.version>
         <vertx.verticle>demo.SimpleVerticle</vertx.verticle>
     </properties>
     <build>

--- a/src/it/run-worker-instances-it/pom.xml
+++ b/src/it/run-worker-instances-it/pom.xml
@@ -24,7 +24,7 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <vertx.version>4.3.1</vertx.version>
+        <vertx.version>@vertx-core.version@</vertx.version>
         <vertx.verticle>org.vertx.demo.SimpleVerticle</vertx.verticle>
     </properties>
     <build>

--- a/src/it/run-worker-it/pom.xml
+++ b/src/it/run-worker-it/pom.xml
@@ -24,7 +24,7 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <vertx.version>4.3.1</vertx.version>
+        <vertx.version>@vertx-core.version@</vertx.version>
         <vertx.verticle>org.vertx.demo.SimpleVerticle</vertx.verticle>
     </properties>
     <build>

--- a/src/it/run-yaml-config-it/pom.xml
+++ b/src/it/run-yaml-config-it/pom.xml
@@ -25,7 +25,7 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <vertx.version>4.3.1</vertx.version>
+        <vertx.version>@vertx-core.version@</vertx.version>
         <vertx.verticle>org.vertx.demo.SimpleVerticle</vertx.verticle>
     </properties>
     <build>

--- a/src/it/run-yaml-options-it/pom.xml
+++ b/src/it/run-yaml-options-it/pom.xml
@@ -25,7 +25,7 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <vertx.version>4.3.1</vertx.version>
+        <vertx.version>@vertx-core.version@</vertx.version>
         <vertx.verticle>org.vertx.demo.SimpleVerticle</vertx.verticle>
     </properties>
     <build>

--- a/src/it/signed-jar-it/pom.xml
+++ b/src/it/signed-jar-it/pom.xml
@@ -25,7 +25,7 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <vertx.version>4.3.1</vertx.version>
+        <vertx.version>@vertx-core.version@</vertx.version>
         <vertx.verticle>org.vertx.demo.MainVerticle</vertx.verticle>
     </properties>
     <build>

--- a/src/main/asciidoc/inc/_vertx-setup.adoc
+++ b/src/main/asciidoc/inc/_vertx-setup.adoc
@@ -17,11 +17,11 @@ if you wish to override the vertx version, then you can run the same command as 
 e.g.
 [source,subs=attributes+]
 ----
-mvn io.reactiverse:vertx-maven-plugin:{version}:setup -DvertxVersion=4.3.1
+mvn io.reactiverse:vertx-maven-plugin:{version}:setup -DvertxVersion={vertx-core-version}
 ----
 
-This will configure the vert.x and its dependencies to `4.3.1` i.e. Maven project property `vertx.version`
-set to `4.3.1`
+This will configure the vert.x and its dependencies to `{vertx-core-version}` i.e. Maven project property `vertx.version`
+set to `{vertx-core-version}`
 
 You can also generate a project if you don't have a `pom.xml` file:
 
@@ -45,7 +45,7 @@ addition, you can configure dependencies using the following syntax: `groupId:ar
 ----
 io.vertx:vertxcodetrans => Inherit version from BOM
 commons-io:commons-io:2.5 => Regular dependency
-io.vertx:vertx-template-engines:4.3.1:shaded => Dependency with classifier
+io.vertx:vertx-template-engines:{vertx-core-version}:shaded => Dependency with classifier
 ----
 
 When creating a project, the `java.specification.version` system property is used to configure the Maven compiler plugin in the new POM file.

--- a/src/main/asciidoc/index.adoc
+++ b/src/main/asciidoc/index.adoc
@@ -7,6 +7,7 @@ Kamesh Sampath, Roland Huß, Clement Escoffier, Thomas Segismont;
 :toc-title: Vert.x Maven Plugin
 :doctype: book
 :icons: font
+:vertx-core-version:
 
 ifndef::ebook-format[:leveloffset: 1]
 

--- a/src/test/java/io/reactiverse/vertx/maven/plugin/ExtraManifestInfoTest.java
+++ b/src/test/java/io/reactiverse/vertx/maven/plugin/ExtraManifestInfoTest.java
@@ -19,6 +19,7 @@ package io.reactiverse.vertx.maven.plugin;
 import io.reactiverse.vertx.maven.plugin.components.impl.ProjectManifestCustomizer;
 import io.reactiverse.vertx.maven.plugin.components.impl.SCMManifestCustomizer;
 import io.reactiverse.vertx.maven.plugin.mojos.PackageMojo;
+import io.reactiverse.vertx.maven.plugin.utils.VertxCoreVersion;
 import org.apache.maven.model.Model;
 import org.apache.maven.model.io.xpp3.MavenXpp3Reader;
 import org.apache.maven.project.MavenProject;
@@ -91,7 +92,7 @@ public class ExtraManifestInfoTest extends PlexusTestCase {
         assertThat(attributes.getValue("Manifest-Version")).isEqualTo("1.0");
         assertThat(attributes.getValue(PROJECT_NAME.header())).isEqualTo("vertx-demo");
         assertThat(attributes.getValue(BUILD_TIMESTAMP.header())).isNotNull().isNotEmpty();
-        assertThat(attributes.getValue(PROJECT_DEPS.header())).isEqualTo("io.vertx:vertx-core:4.3.1");
+        assertThat(attributes.getValue(PROJECT_DEPS.header())).isEqualTo("io.vertx:vertx-core:" + VertxCoreVersion.VALUE);
         assertThat(attributes.getValue(PROJECT_GROUP_ID.header())).isEqualTo("org.vertx.demo");
         assertThat(attributes.getValue(PROJECT_VERSION.header())).isEqualTo("1.0.0-SNAPSHOT");
 
@@ -128,7 +129,7 @@ public class ExtraManifestInfoTest extends PlexusTestCase {
         assertThat(attributes.getValue("Manifest-Version")).isEqualTo("1.0");
         assertThat(attributes.getValue(PROJECT_NAME.header())).isEqualTo("vertx-demo");
         assertThat(attributes.getValue(BUILD_TIMESTAMP.header())).isNotNull().isNotEmpty();
-        assertThat(attributes.getValue(PROJECT_DEPS.header())).isEqualTo("com.example:example:4.3.1:vertx");
+        assertThat(attributes.getValue(PROJECT_DEPS.header())).isEqualTo("com.example:example:" + VertxCoreVersion.VALUE + ":vertx");
         assertThat(attributes.getValue(PROJECT_GROUP_ID.header())).isEqualTo("org.vertx.demo");
         assertThat(attributes.getValue(PROJECT_VERSION.header())).isEqualTo("1.0.0-SNAPSHOT");
     }

--- a/src/test/java/io/reactiverse/vertx/maven/plugin/it/ExtraManifestInfoIT.java
+++ b/src/test/java/io/reactiverse/vertx/maven/plugin/it/ExtraManifestInfoIT.java
@@ -18,6 +18,7 @@ package io.reactiverse.vertx.maven.plugin.it;
 
 import io.reactiverse.vertx.maven.plugin.model.ExtraManifestKeys;
 import io.reactiverse.vertx.maven.plugin.util.GitUtil;
+import io.reactiverse.vertx.maven.plugin.utils.VertxCoreVersion;
 import org.apache.maven.it.VerificationException;
 import org.apache.maven.it.Verifier;
 import org.eclipse.jgit.api.Git;
@@ -152,8 +153,7 @@ public class ExtraManifestInfoIT extends VertxMojoTestBase {
             assertThat(matcher.matches()).isTrue();
 
             assertThat(projectDeps)
-                .isEqualToIgnoringWhitespace("io.vertx:vertx-core:4.3.1 io.vertx:vertx-web:4.3.1 io" +
-                    ".vertx:vertx-jdbc-client:4.3.1");
+                .isEqualToIgnoringWhitespace("io.vertx:vertx-core:" + VertxCoreVersion.VALUE + " io.vertx:vertx-web:" + VertxCoreVersion.VALUE + " io" + ".vertx:vertx-jdbc-client:" + VertxCoreVersion.VALUE);
         } else if ("svn".equalsIgnoreCase(scm)) {
             String scmType = manifest.getMainAttributes().getValue(
                 ExtraManifestKeys.SCM_TYPE.header());
@@ -164,7 +164,7 @@ public class ExtraManifestInfoIT extends VertxMojoTestBase {
             assertThat(revision).isNotNull();
             assertThat(revision).isEqualTo("1381106");
             assertThat(projectDeps)
-                .isEqualToIgnoringWhitespace("io.vertx:vertx-core:4.3.1 io.vertx:vertx-web:4.3.1");
+                .isEqualToIgnoringWhitespace("io.vertx:vertx-core:" + VertxCoreVersion.VALUE + " io.vertx:vertx-web:" + VertxCoreVersion.VALUE);
         }
 
     }

--- a/src/test/java/io/reactiverse/vertx/maven/plugin/it/SetupIT.java
+++ b/src/test/java/io/reactiverse/vertx/maven/plugin/it/SetupIT.java
@@ -1,6 +1,7 @@
 package io.reactiverse.vertx.maven.plugin.it;
 
 import com.google.common.collect.ImmutableList;
+import io.reactiverse.vertx.maven.plugin.utils.VertxCoreVersion;
 import org.apache.commons.io.FileUtils;
 import org.apache.maven.it.VerificationException;
 import org.apache.maven.it.Verifier;
@@ -97,15 +98,14 @@ public class SetupIT extends VertxMojoTestBase {
         assertThat(testDir).isDirectory();
         initVerifier(testDir);
         setup(verifier, "-DprojectGroupId=org.acme", "-DprojectArtifactId=acme",
-            "-Dverticle=org.acme.MyVerticle.java", "-Ddependencies=io.vertx:codetrans,commons-io:commons-io:2.5,io" +
-                ".vertx:vertx-template-engines:4.3.1:shaded");
+            "-Dverticle=org.acme.MyVerticle.java", "-Ddependencies=io.vertx:codetrans,commons-io:commons-io:2.5,io" + ".vertx:vertx-template-engines:" + VertxCoreVersion.VALUE + ":shaded");
         assertThat(new File(testDir, "pom.xml")).isFile();
         assertThat(new File(testDir, "src/main/java")).isDirectory();
         assertThat(new File(testDir, "src/main/java/org/acme/MyVerticle.java")).isFile();
         assertThat(FileUtils.readFileToString(new File(testDir, "pom.xml"), "UTF-8"))
             .contains("<artifactId>codetrans</artifactId>")
             .contains("<artifactId>commons-io</artifactId>", "<version>2.5</version>", "<groupId>commons-io</groupId>")
-            .contains("<artifactId>vertx-template-engines</artifactId>", "<version>4.3.1</version>",
+            .contains("<artifactId>vertx-template-engines</artifactId>", "<version>" + VertxCoreVersion.VALUE + "</version>",
                 "<classifier>shaded</classifier>");;
     }
 

--- a/src/test/java/io/reactiverse/vertx/maven/plugin/it/VertxMojoTestBase.java
+++ b/src/test/java/io/reactiverse/vertx/maven/plugin/it/VertxMojoTestBase.java
@@ -2,6 +2,7 @@ package io.reactiverse.vertx.maven.plugin.it;
 
 
 import com.google.common.collect.ImmutableMap;
+import io.reactiverse.vertx.maven.plugin.utils.VertxCoreVersion;
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.io.IOUtils;
 import org.apache.maven.it.VerificationException;
@@ -19,7 +20,6 @@ import java.util.Properties;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.logging.Level;
-import java.util.logging.LogManager;
 import java.util.logging.Logger;
 
 import static com.jayway.awaitility.Awaitility.await;
@@ -47,7 +47,8 @@ public class VertxMojoTestBase {
         VARIABLES = ImmutableMap.of(
             "@project.groupId@", "io.reactiverse",
             "@project.artifactId@", "vertx-maven-plugin",
-            "@project.version@", VERSION);
+            "@project.version@", VERSION,
+            "@vertx-core.version@", VertxCoreVersion.VALUE);
     }
 
     boolean isCoverage() {

--- a/src/test/java/io/reactiverse/vertx/maven/plugin/utils/VertxCoreVersion.java
+++ b/src/test/java/io/reactiverse/vertx/maven/plugin/utils/VertxCoreVersion.java
@@ -1,0 +1,17 @@
+package io.reactiverse.vertx.maven.plugin.utils;
+
+public class VertxCoreVersion {
+
+    public static final String VALUE;
+
+    static {
+        VALUE = System.getProperty("vertx-core.version");
+        if (VALUE == null) {
+            throw new RuntimeException("vertx-core.version not set");
+        }
+    }
+
+    private VertxCoreVersion() {
+        // Constant class
+    }
+}

--- a/src/test/resources/projects/debug-it/pom.xml
+++ b/src/test/resources/projects/debug-it/pom.xml
@@ -25,7 +25,7 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <vertx.version>4.3.1</vertx.version>
+        <vertx.version>@vertx-core.version@</vertx.version>
     </properties>
     <build>
         <plugins>

--- a/src/test/resources/projects/debug-with-jvmArgs-it/pom.xml
+++ b/src/test/resources/projects/debug-with-jvmArgs-it/pom.xml
@@ -25,7 +25,7 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <vertx.version>4.3.1</vertx.version>
+        <vertx.version>@vertx-core.version@</vertx.version>
     </properties>
     <build>
         <plugins>

--- a/src/test/resources/projects/debug-with-main-class-it/pom.xml
+++ b/src/test/resources/projects/debug-with-main-class-it/pom.xml
@@ -25,7 +25,7 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <vertx.version>4.3.1</vertx.version>
+        <vertx.version>@vertx-core.version@</vertx.version>
     </properties>
     <build>
         <plugins>

--- a/src/test/resources/projects/manifest-git-it/pom.xml
+++ b/src/test/resources/projects/manifest-git-it/pom.xml
@@ -31,7 +31,7 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <vertx.version>4.3.1</vertx.version>
+        <vertx.version>@vertx-core.version@</vertx.version>
     </properties>
     <build>
         <plugins>

--- a/src/test/resources/projects/manifest-svn-it/pom.xml
+++ b/src/test/resources/projects/manifest-svn-it/pom.xml
@@ -29,7 +29,7 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <vertx.version>4.3.1</vertx.version>
+        <vertx.version>@vertx-core.version@</vertx.version>
     </properties>
     <build>
         <plugins>

--- a/src/test/resources/projects/packaging-alternative-output-it/pom.xml
+++ b/src/test/resources/projects/packaging-alternative-output-it/pom.xml
@@ -25,7 +25,7 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <vertx.version>4.3.1</vertx.version>
+        <vertx.version>@vertx-core.version@</vertx.version>
     </properties>
     <build>
         <plugins>

--- a/src/test/resources/projects/packaging-duplicate-it/pom.xml
+++ b/src/test/resources/projects/packaging-duplicate-it/pom.xml
@@ -25,7 +25,7 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <vertx.version>4.3.1</vertx.version>
+        <vertx.version>@vertx-core.version@</vertx.version>
     </properties>
     <build>
         <plugins>

--- a/src/test/resources/projects/packaging-meta-inf-it/pom.xml
+++ b/src/test/resources/projects/packaging-meta-inf-it/pom.xml
@@ -25,7 +25,7 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <vertx.version>4.3.1</vertx.version>
+        <vertx.version>@vertx-core.version@</vertx.version>
     </properties>
     <build>
         <plugins>

--- a/src/test/resources/projects/redeploy-it/pom.xml
+++ b/src/test/resources/projects/redeploy-it/pom.xml
@@ -25,7 +25,7 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <vertx.version>4.3.1</vertx.version>
+        <vertx.version>@vertx-core.version@</vertx.version>
     </properties>
     <build>
         <plugins>

--- a/src/test/resources/projects/redeploy-on-resource-change-it/pom.xml
+++ b/src/test/resources/projects/redeploy-on-resource-change-it/pom.xml
@@ -25,7 +25,7 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <vertx.version>4.3.1</vertx.version>
+        <vertx.version>@vertx-core.version@</vertx.version>
     </properties>
     <build>
         <plugins>

--- a/src/test/resources/projects/redeploy-scan-period-it/pom.xml
+++ b/src/test/resources/projects/redeploy-scan-period-it/pom.xml
@@ -25,7 +25,7 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <vertx.version>4.3.1</vertx.version>
+        <vertx.version>@vertx-core.version@</vertx.version>
     </properties>
     <build>
         <plugins>

--- a/src/test/resources/projects/redeploy-with-custom-launcher-it/pom.xml
+++ b/src/test/resources/projects/redeploy-with-custom-launcher-it/pom.xml
@@ -25,7 +25,7 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <vertx.version>4.3.1</vertx.version>
+        <vertx.version>@vertx-core.version@</vertx.version>
     </properties>
     <build>
         <plugins>

--- a/src/test/resources/projects/redeploy-with-extended-launcher-it/pom.xml
+++ b/src/test/resources/projects/redeploy-with-extended-launcher-it/pom.xml
@@ -25,7 +25,7 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <vertx.version>4.3.1</vertx.version>
+        <vertx.version>@vertx-core.version@</vertx.version>
     </properties>
     <build>
         <plugins>

--- a/src/test/resources/projects/redeploy-with-jvmArgs-it/pom.xml
+++ b/src/test/resources/projects/redeploy-with-jvmArgs-it/pom.xml
@@ -25,7 +25,7 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <vertx.version>4.3.1</vertx.version>
+        <vertx.version>@vertx-core.version@</vertx.version>
     </properties>
     <build>
         <plugins>

--- a/src/test/resources/projects/redeploy-with-some-plugin-it/pom.xml
+++ b/src/test/resources/projects/redeploy-with-some-plugin-it/pom.xml
@@ -25,7 +25,7 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <vertx.version>4.3.1</vertx.version>
+        <vertx.version>@vertx-core.version@</vertx.version>
     </properties>
     <build>
         <plugins>

--- a/src/test/resources/projects/run-filtering-it/pom.xml
+++ b/src/test/resources/projects/run-filtering-it/pom.xml
@@ -25,7 +25,7 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <vertx.version>4.3.1</vertx.version>
+        <vertx.version>@vertx-core.version@</vertx.version>
 
         <!-- Message injected in the resource -->
         <message>aloha</message>

--- a/src/test/resources/projects/start-exploded-it/pom.xml
+++ b/src/test/resources/projects/start-exploded-it/pom.xml
@@ -25,7 +25,7 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <vertx.version>4.3.1</vertx.version>
+        <vertx.version>@vertx-core.version@</vertx.version>
     </properties>
     <build>
         <plugins>

--- a/src/test/resources/projects/start-it/pom.xml
+++ b/src/test/resources/projects/start-it/pom.xml
@@ -25,7 +25,7 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <vertx.version>4.3.1</vertx.version>
+        <vertx.version>@vertx-core.version@</vertx.version>
     </properties>
     <build>
         <plugins>

--- a/src/test/resources/projects/start-java-opts-it/pom.xml
+++ b/src/test/resources/projects/start-java-opts-it/pom.xml
@@ -25,7 +25,7 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <vertx.version>4.3.1</vertx.version>
+        <vertx.version>@vertx-core.version@</vertx.version>
         <vertx.verticle>org.vertx.demo.SimpleVerticle</vertx.verticle>
     </properties>
     <build>

--- a/src/test/resources/projects/start-with-conf-exploded-it/pom.xml
+++ b/src/test/resources/projects/start-with-conf-exploded-it/pom.xml
@@ -25,7 +25,7 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <vertx.version>4.3.1</vertx.version>
+        <vertx.version>@vertx-core.version@</vertx.version>
     </properties>
     <build>
         <plugins>

--- a/src/test/resources/projects/start-with-conf-it/pom.xml
+++ b/src/test/resources/projects/start-with-conf-it/pom.xml
@@ -25,7 +25,7 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <vertx.version>4.3.1</vertx.version>
+        <vertx.version>@vertx-core.version@</vertx.version>
     </properties>
     <build>
         <plugins>

--- a/src/test/resources/projects/start-with-custom-launcher-exploded-it/pom.xml
+++ b/src/test/resources/projects/start-with-custom-launcher-exploded-it/pom.xml
@@ -25,7 +25,7 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <vertx.version>4.3.1</vertx.version>
+        <vertx.version>@vertx-core.version@</vertx.version>
     </properties>
     <build>
         <plugins>

--- a/src/test/resources/projects/start-with-custom-launcher-it/pom.xml
+++ b/src/test/resources/projects/start-with-custom-launcher-it/pom.xml
@@ -25,7 +25,7 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <vertx.version>4.3.1</vertx.version>
+        <vertx.version>@vertx-core.version@</vertx.version>
     </properties>
     <build>
         <plugins>

--- a/src/test/resources/projects/start-with-main-class-exploded-it/pom.xml
+++ b/src/test/resources/projects/start-with-main-class-exploded-it/pom.xml
@@ -25,7 +25,7 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <vertx.version>4.3.1</vertx.version>
+        <vertx.version>@vertx-core.version@</vertx.version>
     </properties>
     <build>
         <plugins>

--- a/src/test/resources/projects/start-with-main-class-it/pom.xml
+++ b/src/test/resources/projects/start-with-main-class-it/pom.xml
@@ -25,7 +25,7 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <vertx.version>4.3.1</vertx.version>
+        <vertx.version>@vertx-core.version@</vertx.version>
     </properties>
     <build>
         <plugins>

--- a/src/test/resources/unit/jar-packaging/pom-extramf-classifier-jar.xml
+++ b/src/test/resources/unit/jar-packaging/pom-extramf-classifier-jar.xml
@@ -29,12 +29,12 @@
             <groupId>com.example</groupId>
             <artifactId>example</artifactId>
             <classifier>vertx</classifier>
-            <version>4.3.1</version>
+            <version>4.5.8</version>
         </dependency>
         <dependency>
             <groupId>io.vertx</groupId>
             <artifactId>vertx-unit</artifactId>
-            <version>4.3.1</version>
+            <version>4.5.8</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/src/test/resources/unit/jar-packaging/pom-extramf-jar.xml
+++ b/src/test/resources/unit/jar-packaging/pom-extramf-jar.xml
@@ -28,12 +28,12 @@
         <dependency>
             <groupId>io.vertx</groupId>
             <artifactId>vertx-core</artifactId>
-            <version>4.3.1</version>
+            <version>4.5.8</version>
         </dependency>
         <dependency>
             <groupId>io.vertx</groupId>
             <artifactId>vertx-unit</artifactId>
-            <version>4.3.1</version>
+            <version>4.5.8</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/src/test/resources/unit/jar-packaging/pom-extramf-scm-jar.xml
+++ b/src/test/resources/unit/jar-packaging/pom-extramf-scm-jar.xml
@@ -42,7 +42,7 @@
         <dependency>
             <groupId>io.vertx</groupId>
             <artifactId>vertx-unit</artifactId>
-            <version>4.3.1</version>
+            <version>4.5.8</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/src/test/resources/unit/jar-packaging/pom-jar.xml
+++ b/src/test/resources/unit/jar-packaging/pom-jar.xml
@@ -53,7 +53,7 @@
     </build>
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <vertx.version>4.3.1</vertx.version>
+        <vertx.version>4.5.8</vertx.version>
         <vertx.verticle>org.vertx.demo.MainVerticle</vertx.verticle>
     </properties>
     <dependencies>


### PR DESCRIPTION
Upgraded to Vert.x 4.5.8

The tested Vert.x version was hardcoded in many places, making it difficult to upgrade.