### PR TITLE
Run goal does not support snapshots

### DIFF
--- a/src/main/java/io/reactiverse/vertx/maven/plugin/mojos/AbstractVertxMojo.java
+++ b/src/main/java/io/reactiverse/vertx/maven/plugin/mojos/AbstractVertxMojo.java
@@ -21,6 +21,7 @@ import io.reactiverse.vertx.maven.plugin.components.ManifestCustomizerService;
 import io.reactiverse.vertx.maven.plugin.components.ServiceUtils;
 import io.reactiverse.vertx.maven.plugin.utils.WebJars;
 import org.apache.maven.artifact.Artifact;
+import org.apache.maven.artifact.ArtifactUtils;
 import org.apache.maven.execution.MavenSession;
 import org.apache.maven.lifecycle.LifecycleExecutor;
 import org.apache.maven.plugin.AbstractMojo;
@@ -301,7 +302,7 @@ public abstract class AbstractVertxMojo extends AbstractMojo implements Contextu
         if (artifact.hasClassifier()) {
             artifactCords.append(":").append(artifact.getClassifier());
         }
-        artifactCords.append(":").append(artifact.getVersion());
+        artifactCords.append(":").append(ArtifactUtils.toSnapshotVersion(artifact.getVersion()));
         return artifactCords.toString();
     }
 

--- a/src/test/java/io/reactiverse/vertx/maven/plugin/it/RunIT.java
+++ b/src/test/java/io/reactiverse/vertx/maven/plugin/it/RunIT.java
@@ -8,7 +8,6 @@ import org.junit.After;
 import org.junit.Test;
 
 import java.io.File;
-import java.io.IOException;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -65,6 +64,20 @@ public class RunIT extends VertxMojoTestBase {
 
         String response = getHttpResponse();
         assertThat(response).contains("aloha").contains("This file");
+    }
+
+    @Test
+    public void testRunAppUsingVertxSnapshotVersion() throws Exception {
+        File testDir = initProject("projects/run-vertx-snapshot-it");
+        assertThat(testDir).isDirectory();
+
+        initVerifier(testDir);
+        prepareProject(testDir, verifier);
+
+        run(verifier, "clean");
+
+        String response = getHttpResponse();
+        assertThat(response).isEqualTo("aloha");
     }
 
     private void run(Verifier verifier, String ... previous) throws VerificationException {

--- a/src/test/resources/projects/run-vertx-snapshot-it/pom.xml
+++ b/src/test/resources/projects/run-vertx-snapshot-it/pom.xml
@@ -1,0 +1,79 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~
+  ~   Copyright (c) 2016-2018 Red Hat, Inc.
+  ~
+  ~   Red Hat licenses this file to you under the Apache License, version
+  ~   2.0 (the "License"); you may not use this file except in compliance
+  ~   with the License.  You may obtain a copy of the License at
+  ~
+  ~      http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~   Unless required by applicable law or agreed to in writing, software
+  ~   distributed under the License is distributed on an "AS IS" BASIS,
+  ~   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+  ~   implied.  See the License for the specific language governing
+  ~   permissions and limitations under the License.
+  -->
+
+<project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://maven.apache.org/POM/4.0.0"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <groupId>io.reactiverse.vmp.it</groupId>
+    <artifactId>vertx-demo-start</artifactId>
+    <version>0.0.1.BUILD-SNAPSHOT</version>
+    <properties>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <vertx.version>4.5.8-SNAPSHOT</vertx.version>
+    </properties>
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <version>3.8.1</version>
+                <configuration>
+                    <source>1.8</source>
+                    <target>1.8</target>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>@project.groupId@</groupId>
+                <artifactId>@project.artifactId@</artifactId>
+                <version>@project.version@</version>
+                <executions>
+                    <execution>
+                        <id>vmp</id>
+                        <goals>
+                            <goal>initialize</goal>
+                            <goal>package</goal>
+                        </goals>
+                    </execution>
+                </executions>
+
+                <configuration>
+                    <verticle>demo.SimpleVerticle</verticle>
+                </configuration>
+
+            </plugin>
+        </plugins>
+    </build>
+    <dependencies>
+        <dependency>
+            <groupId>io.vertx</groupId>
+            <artifactId>vertx-core</artifactId>
+        </dependency>
+    </dependencies>
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>io.vertx</groupId>
+                <artifactId>vertx-stack-depchain</artifactId>
+                <version>${vertx.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+</project>

--- a/src/test/resources/projects/run-vertx-snapshot-it/pom.xml
+++ b/src/test/resources/projects/run-vertx-snapshot-it/pom.xml
@@ -76,4 +76,17 @@
             </dependency>
         </dependencies>
     </dependencyManagement>
+    <repositories>
+        <repository>
+            <id>vertx-snapshots-repository</id>
+            <name>Vert.x Snapshots Repository</name>
+            <url>https://s01.oss.sonatype.org/content/repositories/snapshots/</url>
+            <releases>
+                <enabled>false</enabled>
+            </releases>
+            <snapshots>
+                <enabled>true</enabled>
+            </snapshots>
+        </repository>
+    </repositories>
 </project>

--- a/src/test/resources/projects/run-vertx-snapshot-it/src/main/java/demo/SimpleVerticle.java
+++ b/src/test/resources/projects/run-vertx-snapshot-it/src/main/java/demo/SimpleVerticle.java
@@ -1,0 +1,32 @@
+/*
+ *
+ *   Copyright (c) 2016-2018 Red Hat, Inc.
+ *
+ *   Red Hat licenses this file to you under the Apache License, version
+ *   2.0 (the "License"); you may not use this file except in compliance
+ *   with the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ *   implied.  See the License for the specific language governing
+ *   permissions and limitations under the License.
+ */
+
+package demo;
+
+import io.vertx.core.AbstractVerticle;
+
+/**
+ * @author kameshs
+ */
+public class SimpleVerticle extends AbstractVerticle {
+    @Override
+    public void start() throws Exception {
+        vertx.createHttpServer()
+            .requestHandler(req -> req.response().end("aloha"))
+            .listen(8080);
+    }
+}


### PR DESCRIPTION
Fixes #552

The resolved Maven coordinates must be suffixed with -SNAPSHOT instead of the actual file name.