### PR TITLE
Set the Multi-Release attribute automatically

### DIFF
--- a/src/it/package-archive-multi-release-it/invoker.properties
+++ b/src/it/package-archive-multi-release-it/invoker.properties
@@ -1,0 +1,18 @@
+#
+#
+#   Copyright (c) 2024 Red Hat, Inc.
+#
+#   Red Hat licenses this file to you under the Apache License, version
+#   2.0 (the "License"); you may not use this file except in compliance
+#   with the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+#   implied.  See the License for the specific language governing
+#   permissions and limitations under the License.
+#
+invoker.mavenOpts=-agentlib:jdwp=transport=dt_socket,server=y,suspend=y,address=*:5005
+#invoker.debug=false

--- a/src/it/package-archive-multi-release-it/invoker.properties
+++ b/src/it/package-archive-multi-release-it/invoker.properties
@@ -14,5 +14,5 @@
 #   implied.  See the License for the specific language governing
 #   permissions and limitations under the License.
 #
-invoker.mavenOpts=-agentlib:jdwp=transport=dt_socket,server=y,suspend=y,address=*:5005
+#invoker.mavenOpts=-agentlib:jdwp=transport=dt_socket,server=y,suspend=y,address=*:5005
 #invoker.debug=false

--- a/src/it/package-archive-multi-release-it/pom.xml
+++ b/src/it/package-archive-multi-release-it/pom.xml
@@ -1,0 +1,83 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~    Copyright (c) 2024 Red Hat, Inc.
+  ~
+  ~    Red Hat licenses this file to you under the Apache License, version
+  ~    2.0 (the "License"); you may not use this file except in compliance
+  ~    with the License.  You may obtain a copy of the License at
+  ~
+  ~      http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~    Unless required by applicable law or agreed to in writing, software
+  ~    distributed under the License is distributed on an "AS IS" BASIS,
+  ~    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+  ~    implied.  See the License for the specific language governing
+  ~    permissions and limitations under the License.
+  -->
+
+<project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://maven.apache.org/POM/4.0.0"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <groupId>io.reactiverse.vmp.it</groupId>
+    <artifactId>vertx-demo-pkg</artifactId>
+    <version>0.0.1.BUILD-SNAPSHOT</version>
+    <properties>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <vertx.version>@vertx-core.version@</vertx.version>
+        <vertx.verticle>org.vertx.demo.MainVerticle</vertx.verticle>
+    </properties>
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <version>3.8.1</version>
+                <configuration>
+                    <source>1.8</source>
+                    <target>1.8</target>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>@project.groupId@</groupId>
+                <artifactId>@project.artifactId@</artifactId>
+                <version>@project.version@</version>
+                <executions>
+                    <execution>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>package</goal>
+                        </goals>
+                        <configuration>
+                            <runArgs>
+                                <runArg>--cluster</runArg>
+                                <run>-Djava.net.preferIPv4Stack=true</run>
+                            </runArgs>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+    <dependencies>
+        <dependency>
+            <groupId>io.vertx</groupId>
+            <artifactId>vertx-core</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.vertx</groupId>
+            <artifactId>vertx-infinispan</artifactId>
+        </dependency>
+    </dependencies>
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>io.vertx</groupId>
+                <artifactId>vertx-stack-depchain</artifactId>
+                <version>${vertx.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+</project>

--- a/src/it/package-archive-multi-release-it/src/main/java/org/vertx/demo/MainVerticle.java
+++ b/src/it/package-archive-multi-release-it/src/main/java/org/vertx/demo/MainVerticle.java
@@ -1,0 +1,32 @@
+/*
+ *
+ *   Copyright (c) 2024 Red Hat, Inc.
+ *
+ *   Red Hat licenses this file to you under the Apache License, version
+ *   2.0 (the "License"); you may not use this file except in compliance
+ *   with the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ *   implied.  See the License for the specific language governing
+ *   permissions and limitations under the License.
+ */
+
+package org.vertx.demo;
+
+import io.vertx.core.AbstractVerticle;
+import io.vertx.core.Promise;
+
+/**
+ * @author kameshs
+ */
+public class MainVerticle extends AbstractVerticle {
+    @Override
+    public void start() throws Exception {
+        System.out.println("Clustered: " + vertx.isClustered());
+        vertx.close();
+    }
+}

--- a/src/it/package-archive-multi-release-it/verify.groovy
+++ b/src/it/package-archive-multi-release-it/verify.groovy
@@ -1,0 +1,24 @@
+/*
+ *    Copyright (c) 2024 Red Hat, Inc.
+ *
+ *    Red Hat licenses this file to you under the Apache License, version
+ *    2.0 (the "License"); you may not use this file except in compliance
+ *    with the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ *    implied.  See the License for the specific language governing
+ *    permissions and limitations under the License.
+ */
+
+
+import io.reactiverse.vertx.maven.plugin.Verify
+
+File primaryArtifactFile = new File(basedir, "target/vertx-demo-pkg-0.0.1.BUILD-SNAPSHOT.jar")
+assert primaryArtifactFile.exists()
+
+Verify.verifyVertxJar(primaryArtifactFile)
+Verify.verifyContainsInManifest(primaryArtifactFile, "Multi-Release", "true")

--- a/src/main/asciidoc/inc/_archive-config.adoc
+++ b/src/main/asciidoc/inc/_archive-config.adoc
@@ -15,6 +15,11 @@ By default, the plugin:
 * includes all files from `target/classes` (compiled classes from `src/main/resources`, processed resources from `src/main/resources)
 * combines resources from `META-INF/services`, `META-INF/spring.*` and `META-INF/org/apache/logging/log4j/core/config/plugins/Log4j2Plugins.dat`.
 
+[NOTE]
+====
+If the generated uber-jar contains files under `/META-INF/versions/`, the plugin creates a https://docs.oracle.com/en/java/javase/11/docs/specs/jar/jar.html#multi-release-jar-files[Multi-release JAR file].
+In practice, this happens if your project contains files under `/META-INF/versions/` or depends on at least one Multi-release JAR file (e.g. Infinispan).
+====
 
 === Using archive configuration
 

--- a/src/main/asciidoc/inc/_archive-config.adoc
+++ b/src/main/asciidoc/inc/_archive-config.adoc
@@ -1,6 +1,7 @@
 == Archive configuration
 
-The Vert.x Maven Plugin lets you configure the content of the created archive. Typically you can decide:
+The Vert.x Maven Plugin lets you configure the content of the created archive.
+Typically, you can decide:
 
 * which dependency needs to be embedded
 * which files need to be included
@@ -11,14 +12,13 @@ Besides, you can customize the _manifest_.
 By default, the plugin:
 
 * embeds all _compile_ dependencies
-* includes all files from `target/classes` (compiled classes from `src/main/resources`, processed resources from
-`src/main/resources)
+* includes all files from `target/classes` (compiled classes from `src/main/resources`, processed resources from `src/main/resources)
 * combines resources from `META-INF/services`, `META-INF/spring.*` and `META-INF/org/apache/logging/log4j/core/config/plugins/Log4j2Plugins.dat`.
 
 
 === Using archive configuration
 
-In you plugin configuration add the `archive` item:
+In your plugin configuration add the `archive` item:
 
 [source,xml]
 ----
@@ -55,8 +55,8 @@ In you plugin configuration add the `archive` item:
 
 === Configuring embedded dependencies
 
-In the `archive` configuration, you can declare _dependency sets_ which indicate which dependencies must be included and
-excluded. Also for each configure set, you can decide the file to include and exclude.
+In the `archive` configuration, you can declare _dependency sets_ which indicate which dependencies must be included and excluded.
+Also for each configure set, you can decide the file to include and exclude.
 
 Here is an example:
 
@@ -84,24 +84,24 @@ Here is an example:
 </configuration>
 ----
 
-Notice that when a dependency set is configured, no other dependency is embedded, disabling the default. When you
-configure the archive without a dependency set, the default behavior (embedding all _compile_ dependencies) is used.
+Notice that when a dependency set is configured, no other dependency is embedded, disabling the default.
+When you configure the archive without a dependency set, the default behavior (embedding all _compile_ dependencies) is used.
 
 On a dependency set you can configure:
 
-* `includes`: the set of dependencies to specifically include, if not set, include all dependencies not explicitly
-excluded
+* `includes`: the set of dependencies to specifically include, if not set, include all dependencies not explicitly excluded
 * `excludes`: the set of dependencies to exclude
 * `scope`: the scope of the dependency to include, default to `runtime`
-* `useTransitiveDependencies`: a boolean indicating if transitive dependencies from included dependencies must be
-also included in the jar
+* `useTransitiveDependencies`: a boolean indicating if transitive dependencies from included dependencies must be also included in the jar
 * `option`: configure the files to include / exclude from this dependency set
 
-The `option` attribute enable fine-grain tuning of the file to embed. In the example above, the `dtd` files are excluded.
+The `option` attribute enable fine-grain tuning of the file to embed.
+In the example above, the `dtd` files are excluded.
 
 === Embedding specific file
 
-The archive can be configured with a set of _external_ file to include. For instance:
+The archive can be configured with a set of _external_ file to include.
+For instance:
 
 [source,xml]
 ----
@@ -156,7 +156,7 @@ In a `fileSet`, you can configure:
 
 You can also add entries into the `MANIFEST.MF` of the created archive using the `manifest` entry:
 
-[source, xml]
+[source,xml]
 ----
 <executions>
     <execution>
@@ -188,7 +188,7 @@ The files matching these patterns are combined by default:
 
 The `fileCombinationPatterns` attribute allows configuring which files need to be combined:
 
-[source, xml]
+[source,xml]
 ----
 <archive>
     <fileCombinationPatterns>

--- a/src/main/asciidoc/inc/_vertx-package.adoc
+++ b/src/main/asciidoc/inc/_vertx-package.adoc
@@ -7,37 +7,36 @@ This goal packages a Vert.x application as fat or über jar with its dependencie
 ==== Configuration
 
 The package goal has the following parameters apart from the ones mentioned in
- **<<common:configurations,Common Configuration>>**
+**<<common:configurations,Common Configuration>>**
 
 .Package Configuration
-
 [cols="1,5,2,3"]
 |===
 | Element | Description | Property | Default
 
 | serviceProviderCombination
-| Whether or not SPI files (`META-INF/services`) need to be be combined. Accepted valued as `combine` and `none`.
+| Whether SPI files (`META-INF/services`) need to be combined. Accepted valued as `combine` and `none`.
 | &nbsp;
 | combine
 
 | classifier
 | The classifier to add to the artifact generated. If given, the artifact will be attached with that classifier
-  and the main artifact will be deployed as the main artifact. If this is not given (default), it will replace
-  the main artifact and only the Vert.x (fat) jar artifact will be deployed (in the Maven sense). Attaching the
-  artifact allows to deploy it alongside to the original one. Attachment is controlled using the `attach`
-  parameter.
+and the main artifact will be deployed as the main artifact. If this is not given (default), it will replace
+the main artifact and only the Vert.x (fat) jar artifact will be deployed (in the Maven sense). Attaching the
+artifact allows to deploy it alongside to the original one. Attachment is controlled using the `attach`
+parameter.
 | &nbsp;
 | &nbsp;
 
 | attach
-| Whether or not the created archive needs to be attached to the project. If attached, the _fat_ jar is
-  installed and deployed alongside the main artifact (plain jar). Notice that you can't disable attachment if
-  the classifier is not set (it would mean detaching the main artifact).
+| Whether the created archive needs to be attached to the project. If attached, the _fat_ jar is
+installed and deployed alongside the main artifact (plain jar). Notice that you can't disable attachment if
+the classifier is not set (it would mean detaching the main artifact).
 | &nbsp;
 | true
 
 | skipScmMetadata
-| Whether or not the SCM metadata should be retrieved from the SVN or Git repository
+| Whether the SCM metadata should be retrieved from the SVN or Git repository
 | &nbsp;
 | true
 |===

--- a/src/main/java/io/reactiverse/vertx/maven/plugin/components/impl/ShrinkWrapFatJarPackageService.java
+++ b/src/main/java/io/reactiverse/vertx/maven/plugin/components/impl/ShrinkWrapFatJarPackageService.java
@@ -340,6 +340,14 @@ public class ShrinkWrapFatJarPackageService implements PackageService {
         Manifest manifest = new Manifest();
         Attributes attributes = manifest.getMainAttributes();
         attributes.put(Attributes.Name.MANIFEST_VERSION, "1.0");
+
+        if (!entries.containsKey("Multi-Release")) {
+            Node multiReleaseNode = jar.get("/META-INF/versions");
+            if (multiReleaseNode != null && !multiReleaseNode.getChildren().isEmpty()) {
+                attributes.put(new Attributes.Name("Multi-Release"), Boolean.TRUE.toString());
+            }
+        }
+
         if (entries != null) {
             for (Map.Entry<String, String> entry : entries.entrySet()) {
                 attributes.put(new Attributes.Name(entry.getKey()), entry.getValue());
@@ -350,8 +358,6 @@ public class ShrinkWrapFatJarPackageService implements PackageService {
         manifest.write(bout);
         bout.close();
         byte[] bytes = bout.toByteArray();
-        //TODO: merge existing manifest with current one
         jar.setManifest(new ByteArrayAsset(bytes));
-
     }
 }


### PR DESCRIPTION
Closes #472

If the generated uber-jar contains files under /META-INF/versions/, the MANIFEST filed should have the property Multi-Release: true.