### PR TITLE
Add run-multimodule-it integration test

### DIFF
--- a/src/it/run-multimodule-it/app/pom.xml
+++ b/src/it/run-multimodule-it/app/pom.xml
@@ -1,0 +1,83 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~
+  ~   Copyright (c) 2016-2018 Red Hat, Inc.
+  ~
+  ~   Red Hat licenses this file to you under the Apache License, version
+  ~   2.0 (the "License"); you may not use this file except in compliance
+  ~   with the License.  You may obtain a copy of the License at
+  ~
+  ~      http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~   Unless required by applicable law or agreed to in writing, software
+  ~   distributed under the License is distributed on an "AS IS" BASIS,
+  ~   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+  ~   implied.  See the License for the specific language governing
+  ~   permissions and limitations under the License.
+  -->
+
+<project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://maven.apache.org/POM/4.0.0"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>io.reactiverse.vmp.it</groupId>
+        <artifactId>vertx-demo-run-multimodule</artifactId>
+        <version>0.0.1.BUILD-SNAPSHOT</version>
+    </parent>
+    <artifactId>vertx-demo-run-multimodule-app</artifactId>
+    <properties>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <vertx.version>@vertx-core.version@</vertx.version>
+        <vertx.verticle>org.vertx.demo.SimpleVerticle</vertx.verticle>
+        <vertx.skip>false</vertx.skip>
+    </properties>
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <version>3.8.1</version>
+                <configuration>
+                    <source>1.8</source>
+                    <target>1.8</target>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>@project.groupId@</groupId>
+                <artifactId>@project.artifactId@</artifactId>
+                <version>@project.version@</version>
+                <executions>
+                    <execution>
+                        <id>vmp</id>
+                        <goals>
+                            <goal>initialize</goal>
+                            <goal>package</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+    <dependencies>
+        <dependency>
+            <groupId>io.reactiverse.vmp.it</groupId>
+            <artifactId>vertx-demo-run-multimodule-data</artifactId>
+            <version>${project.parent.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>io.vertx</groupId>
+            <artifactId>vertx-core</artifactId>
+        </dependency>
+    </dependencies>
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>io.vertx</groupId>
+                <artifactId>vertx-stack-depchain</artifactId>
+                <version>${vertx.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+</project>

--- a/src/it/run-multimodule-it/app/src/main/java/org/vertx/demo/SimpleVerticle.java
+++ b/src/it/run-multimodule-it/app/src/main/java/org/vertx/demo/SimpleVerticle.java
@@ -1,0 +1,29 @@
+/*
+ *   Copyright (c) 2024 Red Hat, Inc.
+ *
+ *   Red Hat licenses this file to you under the Apache License, version
+ *   2.0 (the "License"); you may not use this file except in compliance
+ *   with the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ *   implied.  See the License for the specific language governing
+ *   permissions and limitations under the License.
+ */
+
+package org.vertx.demo;
+
+import io.vertx.core.AbstractVerticle;
+import io.vertx.core.Promise;
+
+public class SimpleVerticle extends AbstractVerticle {
+    @Override
+    public void start(Promise<Void> startFuture) throws Exception {
+        startFuture.complete();
+        System.out.println(Constants.VALUE);
+        vertx.close();
+    }
+}

--- a/src/it/run-multimodule-it/data/pom.xml
+++ b/src/it/run-multimodule-it/data/pom.xml
@@ -1,0 +1,44 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~
+  ~   Copyright (c) 2016-2018 Red Hat, Inc.
+  ~
+  ~   Red Hat licenses this file to you under the Apache License, version
+  ~   2.0 (the "License"); you may not use this file except in compliance
+  ~   with the License.  You may obtain a copy of the License at
+  ~
+  ~      http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~   Unless required by applicable law or agreed to in writing, software
+  ~   distributed under the License is distributed on an "AS IS" BASIS,
+  ~   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+  ~   implied.  See the License for the specific language governing
+  ~   permissions and limitations under the License.
+  -->
+
+<project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://maven.apache.org/POM/4.0.0"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>io.reactiverse.vmp.it</groupId>
+        <artifactId>vertx-demo-run-multimodule</artifactId>
+        <version>0.0.1.BUILD-SNAPSHOT</version>
+    </parent>
+    <artifactId>vertx-demo-run-multimodule-data</artifactId>
+    <properties>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    </properties>
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <version>3.8.1</version>
+                <configuration>
+                    <source>1.8</source>
+                    <target>1.8</target>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/src/it/run-multimodule-it/data/src/main/java/org/vertx/demo/Constants.java
+++ b/src/it/run-multimodule-it/data/src/main/java/org/vertx/demo/Constants.java
@@ -1,0 +1,21 @@
+/*
+ *   Copyright (c) 2024 Red Hat, Inc.
+ *
+ *   Red Hat licenses this file to you under the Apache License, version
+ *   2.0 (the "License"); you may not use this file except in compliance
+ *   with the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ *   implied.  See the License for the specific language governing
+ *   permissions and limitations under the License.
+ */
+
+package org.vertx.demo;
+
+public interface Constants {
+    String VALUE = "aloha";
+}

--- a/src/it/run-multimodule-it/invoker.properties
+++ b/src/it/run-multimodule-it/invoker.properties
@@ -1,0 +1,20 @@
+#
+#
+#   Copyright (c) 2016-2018 Red Hat, Inc.
+#
+#   Red Hat licenses this file to you under the Apache License, version
+#   2.0 (the "License"); you may not use this file except in compliance
+#   with the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+#   implied.  See the License for the specific language governing
+#   permissions and limitations under the License.
+#
+# invoker.mavenOpts=-Xdebug -Xnoagent -Xrunjdwp:transport=dt_socket,server=y,suspend=y,address=9001
+invoker.debug=false
+invoker.goals=compile ${project.groupId}:${project.artifactId}:${project.version}:run
+

--- a/src/it/run-multimodule-it/pom.xml
+++ b/src/it/run-multimodule-it/pom.xml
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~
+  ~   Copyright (c) 2016-2018 Red Hat, Inc.
+  ~
+  ~   Red Hat licenses this file to you under the Apache License, version
+  ~   2.0 (the "License"); you may not use this file except in compliance
+  ~   with the License.  You may obtain a copy of the License at
+  ~
+  ~      http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~   Unless required by applicable law or agreed to in writing, software
+  ~   distributed under the License is distributed on an "AS IS" BASIS,
+  ~   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+  ~   implied.  See the License for the specific language governing
+  ~   permissions and limitations under the License.
+  -->
+
+<project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://maven.apache.org/POM/4.0.0"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <groupId>io.reactiverse.vmp.it</groupId>
+    <artifactId>vertx-demo-run-multimodule</artifactId>
+    <version>0.0.1.BUILD-SNAPSHOT</version>
+    <packaging>pom</packaging>
+    <properties>
+        <vertx.skip>true</vertx.skip>
+    </properties>
+    <modules>
+        <module>data</module>
+        <module>app</module>
+    </modules>
+</project>

--- a/src/it/run-multimodule-it/verify.groovy
+++ b/src/it/run-multimodule-it/verify.groovy
@@ -1,0 +1,21 @@
+/*
+ *   Copyright (c) 2016-2018 Red Hat, Inc.
+ *
+ *   Red Hat licenses this file to you under the Apache License, version
+ *   2.0 (the "License"); you may not use this file except in compliance
+ *   with the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ *   implied.  See the License for the specific language governing
+ *   permissions and limitations under the License.
+ */
+
+String base = basedir
+def file = new File(base, "build.log")
+assert file.exists()
+assert file.text.contains("Succeeded in deploying verticle")
+assert file.text.contains("aloha")


### PR DESCRIPTION
Closes #486

The test verifies that the vertx.skip can be used to avoid failure when invoking VMP at the root of the project.