### PR TITLE
Intermittent failure in run-worker-instances-it

### DIFF
--- a/src/it/run-worker-instances-it/src/main/java/org/vertx/demo/SimpleVerticle.java
+++ b/src/it/run-worker-instances-it/src/main/java/org/vertx/demo/SimpleVerticle.java
@@ -17,6 +17,7 @@
 package org.vertx.demo;
 
 import io.vertx.core.AbstractVerticle;
+import io.vertx.core.Context;
 import io.vertx.core.Promise;
 
 /**
@@ -24,11 +25,12 @@ import io.vertx.core.Promise;
  */
 public class SimpleVerticle extends AbstractVerticle {
     @Override
-    public void start(Promise<Void> startFuture) throws Exception {
-        int instances = vertx.getOrCreateContext().getInstanceCount();
+    public void start(Promise<Void> startPromise) throws Exception {
+        Context context = vertx.getOrCreateContext();
+        int instances = context.getInstanceCount();
         System.out.println("Instances="+instances);
-        startFuture.complete();
-
+        boolean workerContext = context.isWorkerContext();
+        System.out.println("Worker=" + workerContext);
         vertx.close();
     }
 }

--- a/src/it/run-worker-instances-it/verify.groovy
+++ b/src/it/run-worker-instances-it/verify.groovy
@@ -18,4 +18,4 @@ String base = basedir
 def file = new File(base, "build.log")
 assert file.exists()
 assert file.text.contains("Instances=2")
-assert file.text.contains("Succeeded in deploying worker verticle")
+assert file.text.contains("Worker=true")


### PR DESCRIPTION
Fixes #590

In order to verify that the verticle is bound to a worker context, we can print a statement in the start method instead of expecting the launcher to do it.