### PR TITLE
Use the Maven Compiler Release property

### DIFF
--- a/src/main/resources/templates/pom-template.ftl
+++ b/src/main/resources/templates/pom-template.ftl
@@ -9,8 +9,12 @@
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <#if javaVersion == "1.8">
         <maven.compiler.source>${javaVersion}</maven.compiler.source>
         <maven.compiler.target>${javaVersion}</maven.compiler.target>
+        <#else>
+        <maven.compiler.release>${javaVersion}</maven.compiler.release>
+        </#if>
         <!-- vert.x properties -->
         <vertx.version>${vertxVersion}</vertx.version>
         <#if vertxVerticle??><vertx.verticle>${vertxVerticle}</vertx.verticle></#if>
@@ -36,10 +40,10 @@
             <artifactId>vertx-core</artifactId>
         </dependency>
         <#if vertxVersion?starts_with("5.")>
-            <dependency>
-                <groupId>io.vertx</groupId>
-                <artifactId>vertx-launcher-application</artifactId>
-            </dependency>
+        <dependency>
+            <groupId>io.vertx</groupId>
+            <artifactId>vertx-launcher-application</artifactId>
+        </dependency>
         </#if>
     </dependencies>
 


### PR DESCRIPTION
Closes #598

With JDK9+, we should set the maven.compiler.release property in a POM file generated by the setup mojo, instead of maven.compiler.source and maven.compiler.target.