### PR TITLE
Skip `PrompterImplTest` on Windows

### DIFF
--- a/src/test/java/io/reactiverse/vertx/maven/plugin/components/impl/PrompterImplTest.java
+++ b/src/test/java/io/reactiverse/vertx/maven/plugin/components/impl/PrompterImplTest.java
@@ -1,6 +1,7 @@
 package io.reactiverse.vertx.maven.plugin.components.impl;
 
 import org.apache.commons.io.IOUtils;
+import org.apache.commons.lang3.SystemUtils;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
@@ -8,6 +9,7 @@ import org.junit.Test;
 import java.io.*;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.Assume.assumeFalse;
 
 /**
  * Tests the Prompter implementation.
@@ -23,6 +25,7 @@ public class PrompterImplTest {
 
     @Before
     public void setUp() throws Exception {
+        assumeFalse(SystemUtils.IS_OS_WINDOWS);
         input = new PipedInputStream();
         pipeToInput = new PrintWriter(new PipedOutputStream(input), true);
         output = new ByteArrayOutputStream();


### PR DESCRIPTION
See https://github.com/reactiverse/vertx-maven-plugin/issues/644

Temporarily skip `PrompterImplTest` on Windows.