### PR TITLE
Document how the plugin detects if a custom main class is a launcher

### DIFF
--- a/src/main/asciidoc/inc/_miscellaneous.adoc
+++ b/src/main/asciidoc/inc/_miscellaneous.adoc
@@ -1,6 +1,6 @@
 = Miscellaneous
 
-== How does redeployment work
+== How does redeployment work?
 
 During the _initialize_ phase, the plugin starts observing the mojos (Maven plugins) that are executed.
 
@@ -53,3 +53,18 @@ Then:
 . open the Maven settings file and change the `localRepository` element value to `Y:`
 
 NOTE: Don't forget to open a new terminal so that the environment variable change is visible.
+
+[#_how_does_the_plugin_detect_if_a_custom_main_class_is_a_launcher]
+== How does the plugin detect if a custom main class is a launcher?
+
+Some goals must detect whether a custom main class set with the `launcher` element (see <<common:configurations>>) is a Vert.x launcher.
+
+The Vert.x Maven plugin considers a class is a Vert.x launcher if:
+
+* the project depends on Vert.x 4 and the class extends `io.vertx.core.Launcher`, or
+* the project depends on Vert.x 5 application and:
+** the class extends `io.vertx.launcher.application.VertxApplication`, or
+** the class extends `io.vertx.core.Launcher`.
+
+In the last case, of course, the project must depend on `io.vertx:vertx-launcher-legacy-cli`.
+

--- a/src/main/asciidoc/inc/_vertx-package.adoc
+++ b/src/main/asciidoc/inc/_vertx-package.adoc
@@ -17,7 +17,7 @@ The following are the *MANIFEST.MF* entries that will be added based on the conf
 
 | `vertx.verticle`
 | `Main-Verticle`
-| The main verticle, _i.e._ the entry point of your application. Used when the `Main-Class` is a Vert.x launcher.
+| The main verticle, _i.e._ the entry point of your application. Used when the `Main-Class` <<_how_does_the_plugin_detect_if_a_custom_main_class_is_a_launcher,is a Vert.x launcher>>.
 
 | `vertx.launcher`
 | `Main-Class`

--- a/src/main/asciidoc/inc/_vertx-run.adoc
+++ b/src/main/asciidoc/inc/_vertx-run.adoc
@@ -63,21 +63,21 @@ The patterns must be expressed relatively to the `rootDirectory`.
 | &nbsp;
 
 | `runArgs`
-| The list of arguments that can be passed to the main class, if it is a Vert.x launcher.
+| The list of arguments that can be passed to the main class, if it <<_how_does_the_plugin_detect_if_a_custom_main_class_is_a_launcher,is a Vert.x launcher>>.
 You can also pass the required run arguments using the system property. e.g. `-Dvertx.runArgs="--worker --instances=2"`.
 The system property takes precedence over the plugin configurations
 | `vertx.runArgs`
 | &nbsp;
 
 | `options`
-| The Vert.x configuration file path that will be passed to the main class, if it is a Vert.x launcher, as `-options`.
+| The Vert.x configuration file path that will be passed to the main class, if it <<_how_does_the_plugin_detect_if_a_custom_main_class_is_a_launcher,is a Vert.x launcher>>, as `-options`.
 If a YAML file is configured then it will be converted to JSON by the plugin.
 The converted file will be saved in `${project.outputDir}/conf` directory.
 | `vertx.options`
 | `src/main/options.json` or `src/main/options.yaml` or `src/main/options.yml`
 
 | `config`
-| The verticle configuration file path that will be passed to the main class, if it is a Vert.x launcher, as `-conf`.
+| The verticle configuration file path that will be passed to the main class, if it <<_how_does_the_plugin_detect_if_a_custom_main_class_is_a_launcher,is a Vert.x launcher>>, as `-conf`.
 If a YAML file is configured then it will be converted to JSON by the plugin.
 The converted file will be saved in `${project.outputDir}/conf` directory.
 | `vertx.config`


### PR DESCRIPTION
If the user provides a custom main class, the plugin must determine if it is a launcher. For example, if it is a launcher, the run goal will add several arguments to the command line (like verticle name and number of instances).

This new doc section clarifies how the plugin decides whether the class is a launcher.