### PR TITLE
Re-enable PrompterImplTest on Windows

### DIFF
--- a/src/main/java/io/reactiverse/vertx/maven/plugin/components/impl/PrompterImpl.java
+++ b/src/main/java/io/reactiverse/vertx/maven/plugin/components/impl/PrompterImpl.java
@@ -51,8 +51,7 @@ public class PrompterImpl implements Prompter {
 
     public PrompterImpl(InputStream in, OutputStream out) throws IOException {
         Terminal terminal = TerminalBuilder.builder()
-            .system(false)
-            .jni(false)
+            .provider(TerminalBuilder.PROP_PROVIDER_EXEC)
             .streams(in, out)
             .build();
         console = LineReaderBuilder.builder()

--- a/src/test/java/io/reactiverse/vertx/maven/plugin/components/impl/PrompterImplTest.java
+++ b/src/test/java/io/reactiverse/vertx/maven/plugin/components/impl/PrompterImplTest.java
@@ -1,7 +1,6 @@
 package io.reactiverse.vertx.maven.plugin.components.impl;
 
 import org.apache.commons.io.IOUtils;
-import org.apache.commons.lang3.SystemUtils;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
@@ -9,7 +8,6 @@ import org.junit.Test;
 import java.io.*;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.Assume.assumeFalse;
 
 /**
  * Tests the Prompter implementation.
@@ -25,7 +23,6 @@ public class PrompterImplTest {
 
     @Before
     public void setUp() throws Exception {
-        assumeFalse(SystemUtils.IS_OS_WINDOWS);
         input = new PipedInputStream();
         pipeToInput = new PrintWriter(new PipedOutputStream(input), true);
         output = new ByteArrayOutputStream();


### PR DESCRIPTION
See #644

As advised by jline developer, create the terminal by forcing usage of the exec provider.