### PR TITLE
Fix RunIT#testRunAppUsingVertxSnapshotVersion

### DIFF
--- a/src/test/resources/projects/run-vertx-snapshot-it/pom.xml
+++ b/src/test/resources/projects/run-vertx-snapshot-it/pom.xml
@@ -25,7 +25,7 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <vertx.version>5.0.8-SNAPSHOT</vertx.version>
+        <vertx.version>5.1.0-SNAPSHOT</vertx.version>
     </properties>
     <build>
         <plugins>


### PR DESCRIPTION
5.0.8-SNAPSHOT is no longer available on Central