### PR TITLE
Remove vertx-web js jar from tests

### DIFF
--- a/src/it/webjar-it/pom.xml
+++ b/src/it/webjar-it/pom.xml
@@ -71,13 +71,6 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>io.vertx</groupId>
-            <artifactId>vertx-web</artifactId>
-            <version>3.9.5</version>
-            <classifier>client</classifier>
-            <type>js</type>
-        </dependency>
-        <dependency>
             <groupId>org.webjars</groupId>
             <artifactId>jquery</artifactId>
             <version>3.1.1</version>

--- a/src/it/webjar-it/verify.groovy
+++ b/src/it/webjar-it/verify.groovy
@@ -27,5 +27,4 @@ Verify.verifyVertxJar(primaryArtifactFile)
 
 JarFile jar = new JarFile(primaryArtifactFile)
 assert jar.getEntry("webroot") != null
-assert jar.getEntry("webroot/vertx-web-client.js") != null
 assert jar.getEntry("webroot/jquery/jquery.js") != null

--- a/src/it/webjar-no-strip-it/pom.xml
+++ b/src/it/webjar-no-strip-it/pom.xml
@@ -69,13 +69,6 @@
             <artifactId>vertx-launcher-application</artifactId>
         </dependency>
         <dependency>
-            <groupId>io.vertx</groupId>
-            <artifactId>vertx-web</artifactId>
-            <version>3.9.5</version>
-            <classifier>client</classifier>
-            <type>js</type>
-        </dependency>
-        <dependency>
             <groupId>org.webjars</groupId>
             <artifactId>jquery</artifactId>
             <version>3.1.1</version>

--- a/src/it/webjar-no-strip-it/verify.groovy
+++ b/src/it/webjar-no-strip-it/verify.groovy
@@ -27,5 +27,4 @@ Verify.verifyVertxJar(primaryArtifactFile)
 
 JarFile jar = new JarFile(primaryArtifactFile)
 assert jar.getEntry("assets") != null
-assert jar.getEntry("assets/vertx-web-3.9.5-client.js") != null
 assert jar.getEntry("assets/jquery/3.1.1/jquery.js") != null


### PR DESCRIPTION
This is an outdated artifact, shouldn't be used anymore.

Anyway the webjar feature is tested with the jquery artifact